### PR TITLE
[Phase 1] Implement Ecto schema introspection at compile time

### DIFF
--- a/lib/ectomancer/schema_introspection.ex
+++ b/lib/ectomancer/schema_introspection.ex
@@ -1,0 +1,263 @@
+defmodule Ectomancer.SchemaIntrospection do
+  @moduledoc """
+  Compile-time Ecto schema introspection for generating MCP tools.
+
+  This module provides utilities to read Ecto schema metadata at compile time
+  and use it to generate MCP-compatible tool definitions.
+
+  ## Example
+
+      schema_info = Ectomancer.SchemaIntrospection.analyze(MyApp.Accounts.User)
+      # Returns: %{
+      #   fields: [:id, :email, :name, :inserted_at, :updated_at],
+      #   types: %{id: :id, email: :string, name: :string, ...},
+      #   associations: [%{field: :posts, cardinality: :many, related: MyApp.Blog.Post}],
+      #   primary_key: [:id]
+      # }
+
+  ## Supported Ecto Types
+
+  - `:string` - String values
+  - `:integer` - Integer values
+  - `:float` / `:decimal` - Number values
+  - `:boolean` - Boolean values
+  - `:date` - Date values
+  - `:time` / `:time_usec` - Time values
+  - `:naive_datetime` / `:naive_datetime_usec` - Naive datetime values
+  - `:utc_datetime` / `:utc_datetime_usec` - UTC datetime values
+  - `Ecto.UUID` - UUID values
+  - `{:array, inner}` - Array values
+  - `:map` - Map/object values
+  - Embeds - Embedded schemas
+  """
+
+  @doc """
+  Analyzes an Ecto schema module and returns its metadata.
+
+  ## Parameters
+
+    * `schema_module` - The Ecto schema module to analyze
+
+  ## Returns
+
+    A map containing:
+    * `:fields` - List of field names (atoms)
+    * `:types` - Map of field names to their Ecto types
+    * `:associations` - List of association information
+    * `:primary_key` - List of primary key field names
+    * `:embedded` - Boolean indicating if this is an embedded schema
+
+  ## Examples
+
+      iex> Ectomancer.SchemaIntrospection.analyze(MyApp.Accounts.User)
+      %{
+        fields: [:id, :email, :name, :role, :inserted_at, :updated_at],
+        types: %{
+          id: :id,
+          email: :string,
+          name: :string,
+          role: :string,
+          inserted_at: :utc_datetime,
+          updated_at: :utc_datetime
+        },
+        associations: [
+          %{field: :posts, cardinality: :many, related: MyApp.Blog.Post}
+        ],
+        primary_key: [:id],
+        embedded: false
+      }
+  """
+  @spec analyze(module()) :: %{
+          fields: [atom()],
+          types: %{atom() => any()},
+          associations: [%{field: atom(), cardinality: atom(), related: module()}],
+          primary_key: [atom()],
+          embedded: boolean()
+        }
+  def analyze(schema_module) do
+    unless ecto_schema?(schema_module) do
+      raise ArgumentError,
+            "#{inspect(schema_module)} is not an Ecto schema. " <>
+              "Make sure it uses Ecto.Schema and defines a schema block."
+    end
+
+    fields = schema_module.__schema__(:fields)
+    types = Map.new(fields, fn field -> {field, schema_module.__schema__(:type, field)} end)
+    associations = get_associations(schema_module)
+    primary_key = schema_module.__schema__(:primary_key)
+
+    # Check if this is an embedded schema (embedded schemas don't have :embedded function)
+    embedded =
+      try do
+        schema_module.__schema__(:embedded)
+      rescue
+        _ -> false
+      end
+
+    %{
+      fields: fields,
+      types: types,
+      associations: associations,
+      primary_key: primary_key,
+      embedded: embedded
+    }
+  end
+
+  @doc """
+  Returns true if the module is an Ecto schema.
+
+  ## Examples
+
+      iex> Ectomancer.SchemaIntrospection.ecto_schema?(MyApp.Accounts.User)
+      true
+
+      iex> Ectomancer.SchemaIntrospection.ecto_schema?(String)
+      false
+  """
+  @spec ecto_schema?(module()) :: boolean()
+  def ecto_schema?(module) do
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :__schema__, 1)
+  end
+
+  @doc """
+  Gets all associations for a schema module.
+
+  Returns a list of maps with association metadata.
+  """
+  @spec get_associations(module()) :: [%{field: atom(), cardinality: atom(), related: module()}]
+  def get_associations(schema_module) do
+    schema_module.__schema__(:associations)
+    |> Enum.map(fn assoc_field ->
+      assoc = schema_module.__schema__(:association, assoc_field)
+
+      %{
+        field: assoc_field,
+        cardinality: assoc.cardinality,
+        related: assoc.related
+      }
+    end)
+  end
+
+  @doc """
+  Gets field information including type and nullable status.
+
+  ## Examples
+
+      iex> Ectomancer.SchemaIntrospection.field_info(MyApp.Accounts.User, :email)
+      %{type: :string, nullable: false}
+  """
+  @spec field_info(module(), atom()) :: %{type: any(), nullable: boolean()}
+  def field_info(schema_module, field) do
+    type = schema_module.__schema__(:type, field)
+
+    # Check if field is nullable by looking at the type
+    # Nullable fields in Ecto typically have {:maybe, type} or are virtual
+    nullable =
+      case type do
+        nil -> true
+        _ -> false
+      end
+
+    %{type: type, nullable: nullable}
+  end
+
+  @doc """
+  Returns the primary key field(s) for a schema.
+
+  ## Examples
+
+      iex> Ectomancer.SchemaIntrospection.primary_key(MyApp.Accounts.User)
+      [:id]
+
+      iex> Ectomancer.SchemaIntrospection.primary_key(MyApp.CompositeKeyModel)
+      [:org_id, :user_id]
+  """
+  @spec primary_key(module()) :: [atom()]
+  def primary_key(schema_module) do
+    schema_module.__schema__(:primary_key)
+  end
+
+  @doc """
+  Returns all fields except associations and primary key fields.
+
+  Useful for generating create/update forms.
+
+  ## Examples
+
+      iex> Ectomancer.SchemaIntrospection.writable_fields(MyApp.Accounts.User)
+      [:email, :name, :role]
+  """
+  @type_mapping %{
+    :string => "string",
+    :integer => "integer",
+    :float => "float",
+    :decimal => "decimal",
+    :boolean => "boolean",
+    :date => "date",
+    :time => "time",
+    :time_usec => "time",
+    :naive_datetime => "datetime",
+    :naive_datetime_usec => "datetime",
+    :utc_datetime => "datetime",
+    :utc_datetime_usec => "datetime",
+    :id => "id",
+    :binary_id => "binary_id",
+    :binary => "binary",
+    :map => "map"
+  }
+
+  @spec writable_fields(module()) :: [atom()]
+  def writable_fields(schema_module) do
+    introspection = analyze(schema_module)
+
+    introspection.fields
+    |> Enum.reject(fn field ->
+      field in introspection.primary_key or
+        field in [:inserted_at, :updated_at]
+    end)
+  end
+
+  @doc """
+  Converts an Ecto type to a human-readable string representation.
+
+  ## Examples
+
+      iex> Ectomancer.SchemaIntrospection.type_to_string(:string)
+      "string"
+
+      iex> Ectomancer.SchemaIntrospection.type_to_string({:array, :string})
+      "array of string"
+
+      iex> Ectomancer.SchemaIntrospection.type_to_string(Ecto.UUID)
+      "uuid"
+  """
+  @spec type_to_string(any()) :: String.t()
+  def type_to_string(type) do
+    case type do
+      {:array, inner} ->
+        "array of #{type_to_string(inner)}"
+
+      %Ecto.Embedded{} = embed ->
+        "embed of #{embed.related}"
+
+      module when is_atom(module) ->
+        case Map.get(@type_mapping, module) do
+          nil ->
+            try do
+              module |> Module.split() |> List.last() |> Macro.underscore()
+            rescue
+              _ ->
+                # Not a real module, just return the atom as string
+                Atom.to_string(module)
+            end
+
+          mapped ->
+            mapped
+        end
+
+      _ ->
+        "unknown"
+    end
+  end
+end

--- a/test/ectomancer/schema_introspection_test.exs
+++ b/test/ectomancer/schema_introspection_test.exs
@@ -1,0 +1,228 @@
+defmodule Ectomancer.SchemaIntrospectionTest do
+  use ExUnit.Case
+
+  alias Ectomancer.SchemaIntrospection
+
+  # Define test Ecto schemas
+  defmodule TestUser do
+    use Ecto.Schema
+
+    schema "users" do
+      field(:email, :string)
+      field(:name, :string)
+      field(:age, :integer)
+      field(:active, :boolean)
+      field(:score, :float)
+      field(:settings, :map)
+      field(:tags, {:array, :string})
+      field(:birth_date, :date)
+      field(:last_login, :utc_datetime)
+
+      timestamps()
+    end
+  end
+
+  defmodule TestPost do
+    use Ecto.Schema
+
+    schema "posts" do
+      field(:title, :string)
+      field(:content, :string)
+      field(:published, :boolean, default: false)
+
+      belongs_to(:author, TestUser)
+      has_many(:comments, TestComment)
+
+      timestamps()
+    end
+  end
+
+  defmodule TestComment do
+    use Ecto.Schema
+
+    @primary_key false
+    embedded_schema do
+      field(:body, :string)
+      field(:rating, :integer)
+    end
+  end
+
+  defmodule NotASchema do
+    def some_function, do: :ok
+  end
+
+  describe "analyze/1" do
+    test "analyzes a simple schema" do
+      info = SchemaIntrospection.analyze(TestUser)
+
+      assert is_list(info.fields)
+      assert :email in info.fields
+      assert :name in info.fields
+      assert is_map(info.types)
+      assert info.types.email == :string
+      assert info.types.age == :integer
+      assert info.primary_key == [:id]
+      assert info.embedded == false
+    end
+
+    test "analyzes schema with associations" do
+      info = SchemaIntrospection.analyze(TestPost)
+
+      assert length(info.associations) == 2
+
+      author_assoc = Enum.find(info.associations, &(&1.field == :author))
+      assert author_assoc.cardinality == :one
+      # Check that related is a module
+      assert is_atom(author_assoc.related)
+
+      comments_assoc = Enum.find(info.associations, &(&1.field == :comments))
+      assert comments_assoc.cardinality == :many
+      # Check that related is a module
+      assert is_atom(comments_assoc.related)
+    end
+
+    test "analyzes embedded schema" do
+      info = SchemaIntrospection.analyze(TestComment)
+
+      # Embedded schemas don't have a primary key
+      assert info.primary_key == []
+      assert :body in info.fields
+      assert info.types.body == :string
+    end
+
+    test "raises for non-schema modules" do
+      assert_raise ArgumentError, fn ->
+        SchemaIntrospection.analyze(NotASchema)
+      end
+    end
+
+    test "includes all field types" do
+      info = SchemaIntrospection.analyze(TestUser)
+
+      assert info.types.email == :string
+      assert info.types.age == :integer
+      assert info.types.active == :boolean
+      assert info.types.score == :float
+      assert info.types.settings == :map
+      assert info.types.tags == {:array, :string}
+      assert info.types.birth_date == :date
+      assert info.types.last_login == :utc_datetime
+    end
+
+    test "includes timestamps" do
+      info = SchemaIntrospection.analyze(TestUser)
+
+      assert :inserted_at in info.fields
+      assert :updated_at in info.fields
+      assert info.types.inserted_at == :naive_datetime
+    end
+  end
+
+  describe "ecto_schema?/1" do
+    test "returns true for Ecto schemas" do
+      assert SchemaIntrospection.ecto_schema?(TestUser) == true
+      assert SchemaIntrospection.ecto_schema?(TestPost) == true
+      assert SchemaIntrospection.ecto_schema?(TestComment) == true
+    end
+
+    test "returns false for non-schema modules" do
+      assert SchemaIntrospection.ecto_schema?(NotASchema) == false
+      assert SchemaIntrospection.ecto_schema?(String) == false
+    end
+  end
+
+  describe "get_associations/1" do
+    test "returns associations list" do
+      associations = SchemaIntrospection.get_associations(TestPost)
+
+      assert length(associations) == 2
+      fields = Enum.map(associations, & &1.field)
+      assert :author in fields
+      assert :comments in fields
+    end
+
+    test "returns empty list for schema without associations" do
+      associations = SchemaIntrospection.get_associations(TestUser)
+      assert associations == []
+    end
+  end
+
+  describe "field_info/2" do
+    test "returns field type and nullable status" do
+      info = SchemaIntrospection.field_info(TestUser, :email)
+
+      assert info.type == :string
+      assert info.nullable == false
+    end
+
+    test "returns nil type for non-existent field" do
+      info = SchemaIntrospection.field_info(TestUser, :non_existent)
+
+      assert info.type == nil
+      assert info.nullable == true
+    end
+  end
+
+  describe "primary_key/1" do
+    test "returns primary key fields" do
+      assert SchemaIntrospection.primary_key(TestUser) == [:id]
+      assert SchemaIntrospection.primary_key(TestPost) == [:id]
+    end
+
+    test "returns empty list for schema without primary key" do
+      assert SchemaIntrospection.primary_key(TestComment) == []
+    end
+  end
+
+  describe "writable_fields/1" do
+    test "excludes primary key and timestamps" do
+      fields = SchemaIntrospection.writable_fields(TestUser)
+
+      refute :id in fields
+      refute :inserted_at in fields
+      refute :updated_at in fields
+
+      assert :email in fields
+      assert :name in fields
+      assert :age in fields
+    end
+  end
+
+  describe "type_to_string/1" do
+    test "converts basic types" do
+      assert SchemaIntrospection.type_to_string(:string) == "string"
+      assert SchemaIntrospection.type_to_string(:integer) == "integer"
+      assert SchemaIntrospection.type_to_string(:float) == "float"
+      assert SchemaIntrospection.type_to_string(:boolean) == "boolean"
+      assert SchemaIntrospection.type_to_string(:date) == "date"
+    end
+
+    test "converts datetime types" do
+      assert SchemaIntrospection.type_to_string(:naive_datetime) == "datetime"
+      assert SchemaIntrospection.type_to_string(:utc_datetime) == "datetime"
+      assert SchemaIntrospection.type_to_string(:naive_datetime_usec) == "datetime"
+      assert SchemaIntrospection.type_to_string(:utc_datetime_usec) == "datetime"
+    end
+
+    test "converts array types" do
+      assert SchemaIntrospection.type_to_string({:array, :string}) == "array of string"
+      assert SchemaIntrospection.type_to_string({:array, :integer}) == "array of integer"
+    end
+
+    test "converts nested arrays" do
+      assert SchemaIntrospection.type_to_string({:array, {:array, :string}}) ==
+               "array of array of string"
+    end
+
+    test "converts UUID module" do
+      assert SchemaIntrospection.type_to_string(Ecto.UUID) == "uuid"
+    end
+
+    test "handles unknown types" do
+      # Unknown atom types return the atom as string
+      assert SchemaIntrospection.type_to_string(:unknown_type) == "unknown_type"
+      # Nil returns nil as string
+      assert SchemaIntrospection.type_to_string(nil) == "nil"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements compile-time Ecto schema introspection to enable auto-generation of MCP tools from Ecto schemas.

## What This Enables

This is the foundation for Phase 1 (Ecto Auto-exposure). Instead of manually defining every field:

```elixir
# Without introspection (manual):
tool :create_user do
  param :email, :string, required: true
  param :name, :string, required: true
  param :age, :integer, required: true
  # ... manually define all 20+ fields
end

# With introspection (auto-generated):
expose MyApp.Accounts.User, actions: [:create]
# Automatically reads schema and generates all fields!
```

## Implementation

### Core Features
- **`analyze/1`** - Comprehensive schema analysis returning:
  - `:fields` - List of all field names
  - `:types` - Map of field names to Ecto types
  - `:associations` - has_many/belongs_to metadata
  - `:primary_key` - Primary key field(s)
  - `:embedded` - Whether it's an embedded schema

- **`ecto_schema?/1`** - Check if module is an Ecto schema
- **`get_associations/1`** - Get all associations with cardinality
- **`field_info/2`** - Get type and nullable status for a field
- **`primary_key/1`** - Get primary key field(s)
- **`writable_fields/1`** - Get fields suitable for create/update (excludes PK and timestamps)
- **`type_to_string/1`** - Convert Ecto types to human-readable strings

### Supported Ecto Types
- `:string`, `:integer`, `:float`, `:boolean`
- `:date`, `:time`, `:naive_datetime`, `:utc_datetime`
- `:decimal`, `:id`, `:binary_id`, `:binary`, `:map`
- `{:array, inner}` - Arrays
- `Ecto.UUID` - UUIDs
- Embedded schemas
- Associations (belongs_to, has_many, etc.)

## Testing

- **21 comprehensive tests** covering:
  - Simple schemas with various field types
  - Schemas with associations
  - Embedded schemas
  - Primary key detection
  - Field filtering (writable_fields)
  - Type conversion
  - Edge cases (non-schema modules)

- All **64 tests passing**
- **Credo clean** (no issues)
- **No compiler warnings**

## Example Usage

```elixir
schema_info = Ectomancer.SchemaIntrospection.analyze(MyApp.Accounts.User)
# Returns:
# %{
#   fields: [:id, :email, :name, :age, :inserted_at, :updated_at],
#   types: %{email: :string, name: :string, age: :integer, ...},
#   associations: [%{field: :posts, cardinality: :many, related: MyApp.Blog.Post}],
#   primary_key: [:id],
#   embedded: false
# }
```

## Checklist

- [x] Create Ectomancer.SchemaIntrospection module
- [x] Read `__schema__(:fields)` to get field names
- [x] Read `__schema__(:types)` to get field types
- [x] Read `__schema__(:associations)` for has_many/belongs_to
- [x] Handle all Ecto types: :string, :integer, :float, :boolean, :date, :datetime, Ecto.UUID, {:array, inner}, embeds
- [x] Write tests for various schema configurations
- [x] Refactor for credo compliance

Closes #5