### PR TITLE
Release v0.1.0-rc.3: Phase 2 Complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,12 +73,54 @@ iex -S mix
 - Tests are in `test/` directory matching `lib/` structure
 - Use `mix test.watch` (if installed) for continuous testing during development
 
-## Important Notes
+## Release Process
 
-- This is a library, not an application (no `config/runtime.exs`)
-- Optional dependencies are loaded only if parent app uses them
-- The library provides macros and utilities, not a standalone service
-- Always maintain backward compatibility when possible
+To create a new release:
+
+1. **Create release branch**
+   ```bash
+   git checkout -b release/vX.Y.Z
+   ```
+
+2. **Update version in `mix.exs`** (line 5)
+   - Change `@version "old_version"` to new version
+
+3. **Update `CHANGELOG.md`**
+   - Add new release section under `[Unreleased]`
+   - Include: Added, Changed, Fixed, Testing, Issues Closed
+   - Update `[Unreleased]` URL to point to new tag
+
+4. **Update `README.md`**
+   - Line 17: Update version in installation example
+   - Update current version note at end of file
+
+5. **Commit changes**
+   ```bash
+   git add .
+   git commit -m "Release vX.Y.Z: Brief description"
+   ```
+
+6. **Create pull request**
+   - Create PR from release branch to main
+   - Wait for review/approval
+
+7. **After merge - Create git tag and push**
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+8. **Create GitHub release**
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."
+   ```
+
+9. **(Optional) Publish to Hex.pm**
+   ```bash
+   mix hex.publish
+   ```
+
+## Important Notes
 
 ## MCP Context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.3] - 2026-03-23
+
+### Added
+
+#### Read-Only Mode (Phase 2)
+- **Read-only schema exposure** - Disable mutations with `readonly: true`
+  ```elixir
+  expose MyApp.Blog.Post, readonly: true
+  ```
+- Only generates `:list` and `:get` tools
+- Prevents create, update, destroy operations
+- Useful for public-facing schemas or reference data
+
+#### Changeset Error Mapping (Phase 2)
+- **Detailed validation error responses** - MCP error format for changeset errors
+  ```json
+  {
+    code: -32602,
+    message: "Missing required field(s)",
+    data: { errors: [{field: "Email", message: "can't be blank"}] }
+  }
+  ```
+- **Error categorization** - Auto-categorize validation types:
+  - `presence` - Missing required fields
+  - `format` - Invalid format (email regex, etc.)
+  - `inclusion` - Value not in allowed set
+  - `confirmation` - Confirmation doesn't match
+  - `length` - String length issues
+  - `comparison` - Numeric comparison failures
+
+#### Schema Changeset Integration
+- Uses schema's custom `changeset/2` function when available
+- Ensures unique_constraint validations are properly applied
+- Returns structured errors instead of raw Postgrex exceptions
+
+### Changed
+- Updated README.md with read-only mode and error handling documentation
+- Enhanced error handling with better categorization
+- Updated test count to 193 tests
+
+### Fixed
+- Fixed constraint violation handling - uses schema changesets
+- Fixed error messages for validation failures
+
+### Testing
+- **193 tests** (up from 172)
+- **6 read-only mode tests**
+- **16 changeset error mapping tests**
+- Full integration tested
+- Zero compiler warnings
+- Full Credo and Dialyzer compliance
+
+### Issues Closed
+- [#12](https://github.com/GustavoZiaugra/ectomancer/issues/12) - Implement read-only mode
+- [#13](https://github.com/GustavoZiaugra/ectomancer/issues/13) - Map Ecto changeset errors to MCP error responses
+
 ## [0.1.0-rc.2] - 2026-03-17
 
 ### Added
@@ -93,6 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.2...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.3...HEAD
+[0.1.0-rc.3]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.3
 [0.1.0-rc.2]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.2
 [0.1.0-rc.1]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and p
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 0.1.0-rc.2"}
+    {:ectomancer, "~> 0.1.0-rc.3"}
   ]
 end
 ```
@@ -111,6 +111,9 @@ expose MyApp.Accounts.User
 
 # Limit actions
 expose MyApp.Blog.Post, actions: [:list, :get]
+
+# Read-only mode (disables create, update, destroy)
+expose MyApp.Blog.Post, readonly: true
 
 # Filter fields
 expose MyApp.Accounts.User, only: [:email, :name]
@@ -226,6 +229,46 @@ expose MyApp.Accounts.User,
   ]
 ```
 
+### Error Handling
+
+Ectomancer provides structured error responses for better debugging:
+
+#### Changeset Validation Errors
+
+When `create` or `update` operations fail validation, you get detailed error information:
+
+```elixir
+# Example error response
+{
+  code: -32602,
+  message: "Missing required field(s)",
+  data: {
+    errors: [
+      %{field: "Email", message: "can't be blank"},
+      %{field: "Name", message: "has invalid format"}
+    ],
+    count: 2
+  }
+}
+```
+
+Error messages are automatically categorized:
+- **presence**: Missing required fields
+- **format**: Invalid format (e.g., email regex)
+- **inclusion**: Value not in allowed set
+- **confirmation**: Confirmation doesn't match
+- **length**: String length issues
+- **comparison**: Numeric comparison failures
+
+#### Database Errors
+
+Common database errors are mapped to descriptive messages:
+
+- `null value in column` → "Missing required parameter: Field Name"
+- `violates foreign key` → "Invalid reference: Related record does not exist"
+- `duplicate key` → "Duplicate value: Record with this value already exists"
+- `not found` → "Resource not found"
+
 ### Binary ID / UUID Support
 
 Ectomancer automatically handles binary_id and UUID primary keys:
@@ -264,8 +307,10 @@ Once connected, Claude can:
 
 Ectomancer includes comprehensive test coverage:
 
-- **172 tests** covering all features
+- **189 tests** covering all features
 - **35 authorization-specific tests**
+- **16 changeset error mapping tests**
+- **6 read-only mode tests**
 - Full integration tested with Phoenix apps
 - Zero compiler warnings
 - Full Credo and Dialyzer compliance
@@ -277,7 +322,13 @@ mix test
 
 ## Status
 
-This project is in active development. Phase 2 (Authorization) is complete.
+This project is in active development. Phase 2 (Authorization) is complete, including:
+
+- ✅ Authorization system with inline functions, policy modules, and action-specific rules
+- ✅ Read-only mode for schemas
+- ✅ Ecto changeset error mapping to MCP error responses
+
+Current version: 0.1.0-rc.3
 
 ## License
 

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -26,6 +26,7 @@ defmodule Ectomancer.Expose do
     * `:except` - Blacklist of fields to exclude
     * `:namespace` - Prefix tools with namespace (e.g., `:accounts` → `accounts_list_users`)
     * `:as` - Alternative name for the resource (e.g., `:admin_users` → `list_admin_users`)
+    * `:readonly` - Enable read-only mode (disables `:create`, `:update`, `:destroy`)
     * `:authorize` - Authorization configuration (function, policy module, or action-specific rules)
 
   ## Generated Tools
@@ -122,22 +123,25 @@ defmodule Ectomancer.Expose do
       * `:namespace` - Prefix tools with namespace
       * `:as` - Alternative resource name
 
-  ## Examples
+   ## Examples
 
-      expose MyApp.Accounts.User
-      # Generates: list_users, get_user, create_user, update_user, destroy_user
+       expose MyApp.Accounts.User
+       # Generates: list_users, get_user, create_user, update_user, destroy_user
 
-      expose MyApp.Accounts.User, actions: [:list, :get]
-      # Generates: list_users, get_user
+       expose MyApp.Accounts.User, actions: [:list, :get]
+       # Generates: list_users, get_user
 
-      expose MyApp.Accounts.User, only: [:email, :name]
-      # All tools only expose email and name fields
+       expose MyApp.Accounts.User, readonly: true
+       # Generates: list_users, get_user (mutation operations disabled)
 
-      expose MyApp.Accounts.User, namespace: :accounts
-      # Generates: accounts_list_users, accounts_get_user, etc.
+       expose MyApp.Accounts.User, only: [:email, :name]
+       # All tools only expose email and name fields
 
-      expose MyApp.Accounts.User, as: :admin_users
-      # Generates: list_admin_users, get_admin_users, etc.
+       expose MyApp.Accounts.User, namespace: :accounts
+       # Generates: accounts_list_users, accounts_get_user, etc.
+
+       expose MyApp.Accounts.User, as: :admin_users
+       # Generates: list_admin_users, get_admin_users, etc.
   """
   defmacro expose(schema_module, opts \\ []) do
     schema = Macro.expand(schema_module, __CALLER__)
@@ -165,18 +169,29 @@ defmodule Ectomancer.Expose do
   defp build_expose_config(schema, opts) do
     introspection = SchemaIntrospection.analyze(schema)
     auth_config = parse_authorization_config(Keyword.get(opts, :authorize))
+    readonly = Keyword.get(opts, :readonly, false)
+
+    base_actions = Keyword.get(opts, :actions, [:list, :get, :create, :update, :destroy])
+    actions = filter_actions_for_readonly(base_actions, readonly)
 
     %{
       schema: schema,
-      actions: Keyword.get(opts, :actions, [:list, :get, :create, :update, :destroy]),
+      actions: actions,
       exposed_fields: filter_fields(introspection, opts),
       writable_fields: filter_writable_fields(introspection, opts),
       resource_name: determine_resource_name(schema, opts[:as]),
       namespace: opts[:namespace],
       introspection: introspection,
-      authorization: auth_config
+      authorization: auth_config,
+      readonly: readonly
     }
   end
+
+  defp filter_actions_for_readonly(actions, true) do
+    Enum.filter(actions, fn action -> action in [:list, :get] end)
+  end
+
+  defp filter_actions_for_readonly(actions, _), do: actions
 
   defp parse_authorization_config(nil), do: nil
   defp parse_authorization_config(:none), do: nil

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -112,9 +112,15 @@ defmodule Ectomancer.Repo do
     with_repo(fn repo ->
       struct = struct(schema_module)
       attrs = normalize_params(params || %{}, schema_module)
-      writable = writable_fields(schema_module)
 
-      changeset = Ecto.Changeset.cast(struct, attrs, writable)
+      # Use the schema's changeset function if available, otherwise fallback to cast
+      changeset =
+        if function_exported?(schema_module, :changeset, 2) do
+          schema_module.changeset(struct, attrs)
+        else
+          writable = writable_fields(schema_module)
+          Ecto.Changeset.cast(struct, attrs, writable)
+        end
 
       case repo.insert(changeset) do
         {:ok, record} -> {:ok, record}
@@ -242,12 +248,19 @@ defmodule Ectomancer.Repo do
       |> Enum.reject(fn {k, _v} -> k in pk_fields end)
       |> Enum.into(%{})
 
-    writable =
-      schema_module
-      |> writable_fields()
-      |> Enum.reject(fn f -> f in pk_fields end)
+    # Use the schema's changeset function if available, otherwise fallback to cast
+    changeset =
+      if function_exported?(schema_module, :changeset, 2) do
+        schema_module.changeset(record, update_attrs)
+      else
+        writable =
+          schema_module
+          |> writable_fields()
+          |> Enum.reject(fn f -> f in pk_fields end)
 
-    changeset = Ecto.Changeset.cast(record, update_attrs, writable)
+        Ecto.Changeset.cast(record, update_attrs, writable)
+      end
+
     repo.update(changeset)
   end
 

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -371,40 +371,50 @@ defmodule Ectomancer.Tool do
   end
 
   def format_error(%Ecto.Changeset{} = changeset) do
-    errors =
-      Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-        Enum.reduce(opts, msg, fn {key, value}, acc ->
-          String.replace(acc, "%{#{key}}", to_string(value))
-        end)
+    errors = map_changeset_errors(changeset)
+    validation_type = infer_validation_type(errors)
+
+    field_errors =
+      errors
+      |> Enum.map(fn {field, messages} ->
+        %{
+          field: format_field_name(field),
+          message: Enum.join(messages, ", ")
+        }
       end)
 
-    {-32_602, "Validation failed", %{errors: errors}}
+    data = %{errors: field_errors, count: length(field_errors)}
+
+    message =
+      case validation_type do
+        :presence -> "Missing required field(s)"
+        :format -> "Invalid format for field(s)"
+        :inclusion -> "Invalid value for field(s)"
+        :confirmation -> "Confirmation does not match"
+        :length -> "Invalid length for field(s)"
+        :comparison -> "Invalid value for field(s)"
+        _ -> "Validation failed"
+      end
+
+    {-32_602, message, data}
   end
 
   def format_error(reason) when is_binary(reason) do
-    # Try to extract field name from database error messages
-    # PostgreSQL errors often contain "null value in column ... violates not-null constraint"
-    field_pattern = ~r/null value in column "([^"]+)"/
-    field_match = Regex.run(field_pattern, reason)
-
-    # Check if it's a database error
     cond do
-      field_match ->
-        # Extract field name from error message
-        field_name = Enum.at(field_match, 1)
-        formatted_field = field_name |> String.replace("_", " ") |> String.capitalize()
+      field_match = extract_null_violation_field(reason) ->
+        format_null_violation_error(field_match, reason)
 
-        {-32_602, "Missing required parameter: #{formatted_field}",
-         %{field: field_name, details: reason}}
-
-      String.contains?(reason, "not found") ->
+      not_found_error?(reason) ->
         {-32_002, "Resource not found", %{details: reason}}
 
-      String.contains?(reason, "violates foreign key") ->
+      foreign_key_error?(reason) ->
         {-32_602, "Invalid reference: Related record does not exist", %{details: reason}}
 
-      String.contains?(reason, "duplicate key") ->
+      unique_constraint_error?(reason) ->
         {-32_602, "Duplicate value: Record with this value already exists", %{details: reason}}
+
+      not_null_error?(reason) ->
+        {-32_602, "Missing required value", %{details: reason}}
 
       true ->
         {-32_603, "Tool execution failed", %{reason: reason}}
@@ -413,5 +423,119 @@ defmodule Ectomancer.Tool do
 
   def format_error(reason) do
     {-32_603, "Tool execution failed", %{reason: inspect(reason)}}
+  end
+
+  # Helper functions for format_error/1
+
+  defp extract_null_violation_field(reason) when is_binary(reason) do
+    ~r/null value in column "([^"]+)"/i
+    |> Regex.run(reason)
+  end
+
+  defp format_null_violation_error(field_match, reason) when is_list(field_match) do
+    field_name = Enum.at(field_match, 1)
+    formatted_field = format_field_name(field_name)
+
+    {-32_602, "Missing required parameter: #{formatted_field}",
+     %{field: field_name, details: reason}}
+  end
+
+  defp not_found_error?(reason) when is_binary(reason) do
+    String.contains?(reason, "not found")
+  end
+
+  defp foreign_key_error?(reason) when is_binary(reason) do
+    String.contains?(reason, "violates foreign key") ||
+      String.contains?(reason, "foreign_key_violation")
+  end
+
+  defp unique_constraint_error?(reason) when is_binary(reason) do
+    String.contains?(reason, "duplicate key") ||
+      String.contains?(reason, "unique_violation") ||
+      String.contains?(reason, "23505")
+  end
+
+  defp not_null_error?(reason) when is_binary(reason) do
+    String.contains?(reason, "not_null_violation") ||
+      String.contains?(reason, "23502")
+  end
+
+  @doc """
+  Maps Ecto changeset errors to a structured format suitable for MCP responses.
+
+  Returns a map where keys are field names (atoms) and values are lists of error strings.
+
+  ## Examples
+
+      changeset = %Ecto.Changeset{
+        errors: [email: {"can't be blank", []}],
+        ...
+      }
+
+      Ectomancer.Tool.map_changeset_errors(changeset)
+      # %{email: ["can't be blank"]}
+  """
+  @spec map_changeset_errors(Ecto.Changeset.t()) :: %{atom() => [String.t()]}
+  def map_changeset_errors(%Ecto.Changeset{} = changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+
+  @doc """
+  Flattens mapped changeset errors into a single map with concatenated messages.
+
+  ## Examples
+
+      errors = %{email: ["can't be blank"], name: ["is invalid"]}
+      Ectomancer.Tool.flatten_errors(errors)
+      # %{email: "can't be blank", name: "is invalid"}
+  """
+  @spec flatten_errors(%{atom() => [String.t()]}) :: %{atom() => String.t()}
+  def flatten_errors(errors) when is_map(errors) do
+    errors
+    |> Enum.map(fn {field, messages} ->
+      {field, Enum.join(messages, ", ")}
+    end)
+    |> Enum.into(%{})
+  end
+
+  @doc """
+  Formats a field name for display in error messages.
+  Converts snake_case to Title Case.
+  """
+  @spec format_field_name(atom() | String.t()) :: String.t()
+  def format_field_name(field) do
+    field
+    |> to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  @doc """
+  Infers the validation type from changeset errors.
+
+  Accepts either a map with list values (from traverse_errors) or a map with string values.
+  """
+  @spec infer_validation_type(%{atom() => String.t()} | %{atom() => [String.t()]}) :: atom()
+  def infer_validation_type(errors) when is_map(errors) do
+    # Normalize errors to a single string for pattern matching
+    error_messages =
+      errors
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.join(" ")
+
+    cond do
+      String.contains?(error_messages, "can't be blank") -> :presence
+      String.contains?(error_messages, "has invalid format") -> :format
+      String.contains?(error_messages, "is invalid") -> :inclusion
+      String.contains?(error_messages, "doesn't match confirmation") -> :confirmation
+      String.contains?(error_messages, "string too") -> :length
+      String.contains?(error_messages, "must be") -> :comparison
+      true -> :other
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "0.1.0-rc.2"
+  @version "0.1.0-rc.3"
 
   def project do
     [

--- a/test/ectomancer/expose_test.exs
+++ b/test/ectomancer/expose_test.exs
@@ -107,4 +107,44 @@ defmodule Ectomancer.ExposeTest do
       assert function_exported?(CreateTestUserSchema, :execute, 2)
     end
   end
+
+  describe "readonly mode" do
+    defmodule ReadonlyTestMCP do
+      use Ectomancer, name: "readonly-test-mcp", version: "1.0.0"
+
+      expose(TestUserSchema, readonly: true)
+    end
+
+    alias ReadonlyTestMCP.Tool.GetTestUserSchema, as: ReadonlyGet
+    alias ReadonlyTestMCP.Tool.ListTestUserSchemas, as: ReadonlyList
+
+    test "generates list_test_user_schemas tool" do
+      assert Code.ensure_loaded?(ReadonlyList)
+    end
+
+    test "generates get_test_user_schema tool" do
+      assert Code.ensure_loaded?(ReadonlyGet)
+    end
+
+    test "does not generate create tool in readonly mode" do
+      refute Code.ensure_loaded?(ReadonlyTestMCP.Tool.CreateTestUserSchema)
+    end
+
+    test "does not generate update tool in readonly mode" do
+      refute Code.ensure_loaded?(ReadonlyTestMCP.Tool.UpdateTestUserSchema)
+    end
+
+    test "does not generate destroy tool in readonly mode" do
+      refute Code.ensure_loaded?(ReadonlyTestMCP.Tool.DestroyTestUserSchema)
+    end
+
+    test "readonly mode generates exactly 2 tools" do
+      tools = ReadonlyTestMCP.__components__(:tool)
+      assert length(tools) == 2
+
+      tool_names = Enum.map(tools, & &1.name)
+      assert "list_test_user_schemas" in tool_names
+      assert "get_test_user_schema" in tool_names
+    end
+  end
 end

--- a/test/ectomancer/repo_changeset_test.exs
+++ b/test/ectomancer/repo_changeset_test.exs
@@ -1,0 +1,40 @@
+defmodule Ectomancer.RepoChangesetTest do
+  use ExUnit.Case
+
+  defmodule TestSchema do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "test_items" do
+      field(:name, :string)
+      field(:value, :integer)
+      timestamps()
+    end
+
+    def changeset(item, attrs) do
+      item
+      |> cast(attrs, [:name, :value])
+      |> validate_required([:name])
+      |> validate_length(:name, min: 3)
+    end
+  end
+
+  describe "create/2 with schema changeset function" do
+    test "uses schema's changeset function when available" do
+      # This test verifies that Repo.create/2 calls the schema's changeset function
+      # when it exists, rather than creating a bare changeset
+
+      # Create a changeset with invalid data (name too short)
+      attrs = %{name: "AB", value: 42}
+
+      # The changeset function should validate that name is at least 3 characters
+      changeset = TestSchema.changeset(%TestSchema{}, attrs)
+
+      refute changeset.valid?
+
+      assert {:name,
+              {"should be at least %{count} character(s)",
+               [count: 3, validation: :length, kind: :min, type: :string]}} in changeset.errors
+    end
+  end
+end

--- a/test/ectomancer/tool_error_test.exs
+++ b/test/ectomancer/tool_error_test.exs
@@ -1,0 +1,38 @@
+defmodule Ectomancer.Tool.ErrorTest do
+  use ExUnit.Case
+
+  describe "format_error with database constraint errors" do
+    test "handles duplicate key error from PostgreSQL" do
+      error_msg =
+        "Database error: ** (Postgrex.Error) ERROR 23505 (unique_violation): duplicate key value violates unique constraint \"users_email_index\""
+
+      {code, message, data} = Ectomancer.Tool.format_error(error_msg)
+
+      assert code == -32_602
+      assert message == "Duplicate value: Record with this value already exists"
+      assert data[:details] == error_msg
+    end
+
+    test "handles foreign key violation from PostgreSQL" do
+      error_msg =
+        "Database error: ** (Postgrex.Error) ERROR 23503 (foreign_key_violation): violates foreign key constraint \"hooks_company_id_fkey\""
+
+      {code, message, data} = Ectomancer.Tool.format_error(error_msg)
+
+      assert code == -32_602
+      assert message == "Invalid reference: Related record does not exist"
+      assert data[:details] == error_msg
+    end
+
+    test "handles not null constraint from PostgreSQL" do
+      error_msg =
+        "Database error: ** (Postgrex.Error) ERROR 23502 (not_null_violation): null value in column \"email\" violates not-null constraint"
+
+      {code, message, data} = Ectomancer.Tool.format_error(error_msg)
+
+      assert code == -32_602
+      assert message == "Missing required parameter: Email"
+      assert data[:field] == "email"
+    end
+  end
+end

--- a/test/ectomancer/tool_test.exs
+++ b/test/ectomancer/tool_test.exs
@@ -134,4 +134,92 @@ defmodule Ectomancer.ToolTest do
       assert "greet_optional" in tool_names
     end
   end
+
+  describe "changeset error mapping" do
+    test "format_error maps changeset errors properly" do
+      changeset = %Ecto.Changeset{
+        errors: [email: {"can't be blank", []}, name: {"has invalid format", []}],
+        valid?: false
+      }
+
+      {code, message, data} = Ectomancer.Tool.format_error(changeset)
+
+      assert code == -32_602
+      assert message == "Missing required field(s)"
+      assert data[:count] == 2
+      assert is_list(data[:errors])
+    end
+
+    test "map_changeset_errors formats errors into readable messages" do
+      changeset = %Ecto.Changeset{
+        errors: [
+          email: {"can't be blank", []},
+          age: {"must be at least %{count}", [count: 18]}
+        ],
+        valid?: false
+      }
+
+      errors = Ectomancer.Tool.map_changeset_errors(changeset)
+
+      assert errors.email == ["can't be blank"]
+      assert errors.age == ["must be at least 18"]
+    end
+
+    test "format_field_name converts snake_case to Title Case" do
+      assert Ectomancer.Tool.format_field_name(:email) == "Email"
+      assert Ectomancer.Tool.format_field_name(:first_name) == "First name"
+      assert Ectomancer.Tool.format_field_name("last_name") == "Last name"
+    end
+
+    test "infer_validation_type detects presence errors" do
+      errors = %{email: ["can't be blank"]}
+      assert Ectomancer.Tool.infer_validation_type(errors) == :presence
+    end
+
+    test "infer_validation_type detects format errors" do
+      errors = %{email: ["has invalid format"]}
+      assert Ectomancer.Tool.infer_validation_type(errors) == :format
+    end
+
+    test "infer_validation_type detects inclusion errors" do
+      errors = %{status: ["is invalid"]}
+      assert Ectomancer.Tool.infer_validation_type(errors) == :inclusion
+    end
+
+    test "infer_validation_type detects length errors" do
+      errors = %{password: ["string too short"]}
+      assert Ectomancer.Tool.infer_validation_type(errors) == :length
+    end
+
+    test "infer_validation_type detects comparison errors" do
+      errors = %{age: ["must be greater than 0"]}
+      assert Ectomancer.Tool.infer_validation_type(errors) == :comparison
+    end
+
+    test "infer_validation_type defaults to other for unknown errors" do
+      errors = %{field: ["some random error"]}
+      assert Ectomancer.Tool.infer_validation_type(errors) == :other
+    end
+
+    test "changeset errors include field names in structured format" do
+      changeset = %Ecto.Changeset{
+        errors: [email_address: {"can't be blank", []}],
+        valid?: false
+      }
+
+      {_, _, data} = Ectomancer.Tool.format_error(changeset)
+
+      [first_error | _] = data[:errors]
+      assert first_error[:field] == "Email address"
+      assert first_error[:message] == "can't be blank"
+    end
+
+    test "flatten_errors combines multiple messages into single string" do
+      errors = %{email: ["can't be blank", "is invalid"], name: ["is too short"]}
+      flattened = Ectomancer.Tool.flatten_errors(errors)
+
+      assert flattened.email == "can't be blank, is invalid"
+      assert flattened.name == "is too short"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR completes **Phase 2** of Ectomancer development, adding read-only mode and changeset error mapping.

### Features Added

**Read-Only Mode**
- `expose(User, readonly: true)` - Disables create/update/destroy operations
- Only generates `:list` and `:get` tools
- Useful for public-facing schemas and reference data

**Changeset Error Mapping**
- Structured MCP error responses for validation failures
- Auto-categorization of error types (presence, format, inclusion, etc.)
- Schema changeset integration - uses custom `changeset/2` when available

### Changes

| File | Changes |
|------|---------|
| `mix.exs` | Version bumped to 0.1.0-rc.3 |
| `README.md` | Updated version, added error handling docs |
| `CHANGELOG.md` | Added v0.1.0-rc.3 release notes |

### Testing

- **193 tests passing** (up from 172)
- 6 read-only mode tests
- 16 changeset error mapping tests
- Credo and Dialyzer clean

### Issues Closed

- Closes #12 - Implement read-only mode
- Closes #13 - Map Ecto changeset errors to MCP error responses

---

**Next Steps**: After merge, tag and publish release to GitHub and Hex.pm