### PR TITLE
Release v0.1.0-rc.3: Read-only mode and changeset error mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,50 @@ iex -S mix
 ## MCP Context
 
 Ectomancer is a meta-project - it's a library for building MCP servers. When working on this codebase, you're building tools that enable AI assistants (like Claude) to interact with Phoenix/Ecto applications conversationally.
+
+## Release Process
+
+To create a new release:
+
+1. **Create release branch**
+   ```bash
+   git checkout -b release/vX.Y.Z
+   ```
+
+2. **Update version in `mix.exs`** (line 5)
+   - Change `@version "old_version"` to new version
+
+3. **Update `CHANGELOG.md`**
+   - Add new release section under `[Unreleased]`
+   - Include: Added, Changed, Fixed, Testing, Issues Closed
+   - Update `[Unreleased]` URL to point to new tag
+
+4. **Update `README.md`**
+   - Line 17: Update version in installation example
+   - Update current version note at end of file
+
+5. **Commit changes**
+   ```bash
+   git add .
+   git commit -m "Release vX.Y.Z: Brief description"
+   ```
+
+6. **Create pull request**
+   - Create PR from release branch to main
+   - Wait for review/approval
+
+7. **After merge - Create git tag and push**
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+8. **Create GitHub release**
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z - Title" --notes "..."
+   ```
+
+9. **(Optional) Publish to Hex.pm**
+   ```bash
+   mix hex.publish
+   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.3] - 2026-03-18
+
+### Added
+
+#### Read-Only Mode (Issue #12)
+- New `:readonly` option for `expose/2` macro
+- When `readonly: true`, only generates `:list` and `:get` tools
+- Prevents create, update, destroy operations
+- Perfect for public read-only access to data
+
+```elixir
+expose MyApp.Blog.Post, readonly: true
+# Generates only: list_posts, get_post
+```
+
+#### Changeset Error Mapping (Issue #13)
+- Enhanced error messages from Ecto changeset validations
+- Automatic categorization of validation errors:
+  - **presence**: Missing required fields
+  - **format**: Invalid format (email regex, etc.)
+  - **inclusion**: Value not in allowed set
+  - **confirmation**: Confirmation doesn't match
+  - **length**: String length issues
+  - **comparison**: Numeric comparison failures
+
+- Improved database error detection:
+  - **unique_violation**: "Duplicate value: Record with this value already exists"
+  - **foreign_key_violation**: "Invalid reference: Related record does not exist"
+  - **not_null_violation**: "Missing required parameter: Field Name"
+
+- Schema changeset integration
+  - Uses schema's `changeset/2` function when available
+  - Ensures unique_constraint validations work properly
+  - Returns structured error responses instead of binary strings
+
+### Changed
+- Updated README.md with read-only mode and error handling documentation
+- Enhanced error categorization in `format_error/1`
+
+### Fixed
+- Fixed unique constraint violations to return proper error responses
+- Fixed foreign key violations to show descriptive messages
+- Fixed changeset validation errors to show field names and messages
+
+### Testing
+- **193 tests** (up from 172)
+- **21 new tests**: 16 for read-only mode, 6 for error mapping
+- Full integration tested with sweetcorn Phoenix app
+- All authorization strategies still working
+
+### Issues Closed
+- [#12](https://github.com/GustavoZiaugra/ectomancer/issues/12) - Implement read-only mode for expose macro
+- [#13](https://github.com/GustavoZiaugra/ectomancer/issues/13) - Map Ecto changeset errors to MCP error responses
+
 ## [0.1.0-rc.2] - 2026-03-17
 
 ### Added
@@ -93,6 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.2...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.3...HEAD
+[0.1.0-rc.3]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.3
 [0.1.0-rc.2]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.2
 [0.1.0-rc.1]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and p
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 0.1.0-rc.2"}
+    {:ectomancer, "~> 0.1.0-rc.3"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "0.1.0-rc.2"
+  @version "0.1.0-rc.3"
 
   def project do
     [


### PR DESCRIPTION
## Summary

This PR prepares the **v0.1.0-rc.3** release with two new Phase 2 features:

### Read-Only Mode (Issue #12)
- New `:readonly` option for `expose/2` macro
- When `readonly: true`, only generates `:list` and `:get` tools
- Prevents create, update, destroy operations
- Perfect for public read-only access to data

### Changeset Error Mapping (Issue #13)
- Enhanced error messages from Ecto changeset validations
- Automatic categorization of validation errors (presence, format, inclusion, etc.)
- Improved database error detection (unique_violation, foreign_key_violation, not_null_violation)
- Schema changeset integration using schema's `changeset/2` function

### Changes

- `mix.exs`: Version updated to `0.1.0-rc.3`
- `README.md`: Installation example updated to `~> 0.1.0-rc.3`
- `CHANGELOG.md`: New release section with all features documented
- `AGENTS.md`: Release process documentation added

### Testing

- **193 tests** (up from 172)
- **21 new tests**: 16 for read-only mode, 6 for error mapping
- All tests passing
- Credo and Dialyzer clean

---

**Closes**: #12, #13