### PR TITLE
Release v0.1.0-rc.4: Phoenix route introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-rc.4] - 2026-03-25
+
 ### Added
 
-#### Phoenix Route Introspection (Issue #14)
+#### Phoenix Route Introspection (Issue #14) - Phase 3 Complete!
 - New `expose_routes/1` macro to auto-generate MCP tools from Phoenix router
 - Support for all HTTP methods: GET, POST, PUT, PATCH, DELETE
 - Smart tool naming with automatic singularization:
@@ -175,7 +177,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.3...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.4...HEAD
+[0.1.0-rc.4]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.4
 [0.1.0-rc.3]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.3
 [0.1.0-rc.2]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.2
 [0.1.0-rc.1]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and p
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 0.1.0-rc.3"}
+    {:ectomancer, "~> 0.1.0-rc.4"}
   ]
 end
 ```
@@ -365,7 +365,7 @@ This project is in active development.
 - ✅ Read-only mode for schemas
 - ✅ Ecto changeset error mapping to MCP error responses
 
-Current version: 0.1.0-rc.3
+Current version: 0.1.0-rc.4
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "0.1.0-rc.3"
+  @version "0.1.0-rc.4"
 
   def project do
     [


### PR DESCRIPTION
## Summary

This release completes **Phase 3** of Ectomancer with the new Phoenix route introspection feature.

### What's New

**Phoenix Route Introspection (Issue #14)**
- `expose_routes/1` macro to auto-generate MCP tools from Phoenix router
- Support for all HTTP methods: GET, POST, PUT, PATCH, DELETE
- Smart tool naming with automatic singularization
- Route filtering with `:only`, `:except`, `:methods`, `:namespace` options
- Direct controller action execution via `Plug.Test.conn`

### Usage Example

```elixir
defmodule MyApp.MCP do
  use Ectomancer
  
  # Expose all routes
  expose_routes MyAppWeb.Router
  
  # With filtering
  expose_routes MyAppWeb.Router,
    only: ["/api/users"],
    namespace: :api
end
```

### Changes
- Added `Ectomancer.RouteIntrospection` module
- 179 new tests for comprehensive coverage
- Updated README.md with documentation
- Updated CHANGELOG.md

### Testing
- ✅ All tests passing
- ✅ Credo compliant
- ✅ No compiler warnings
- ✅ Integration tested with sweetcorn Phoenix app

### Issues Closed
- Closes #14

## Release Checklist
- [x] Version bumped to 0.1.0-rc.4
- [x] CHANGELOG.md updated
- [x] Tests passing
- [x] Documentation updated
- [ ] Merge to main
- [ ] Create tag v0.1.0-rc.4
- [ ] Create GitHub release