### PR TITLE
release: v1.0.0 - Official Stable Release (closes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0-rc.4] - 2026-03-25
+## [1.0.0] - 2026-03-29
+
+### 🎉 Official v1.0.0 Release - Production Ready!
+
+Ectomancer is now officially stable and ready for production use! Three phases of development complete.
 
 ### Added
+
+#### Optional Oban Bridge (Issue #15) - Phase 3 Final Feature!
+- New `expose_oban_jobs/0` and `expose_oban_jobs/1` macros for Oban integration
+- Automatically generates 5 MCP tools for job queue management:
+  - `list_oban_queues` - List all queues with job statistics (total, executing, available, retryable, discarded)
+  - `get_queue_depth` - Get detailed counts for a specific queue
+  - `list_stuck_jobs` - Find executing jobs with optional filters (queue, worker, min_age, limit)
+  - `retry_job` - Retry failed or discarded jobs by ID
+  - `cancel_job` - Cancel or delete jobs by ID
+- Only activates when Oban is in dependencies (optional dependency support)
+- Supports `:namespace` option for tool naming (e.g., `background_list_oban_queues`)
+- Comprehensive test coverage (13 tests)
+
+```elixir
+# Expose all Oban job management tools
+expose_oban_jobs
+
+# With namespace prefix
+expose_oban_jobs(namespace: :background)
+# Generates: background_list_oban_queues, background_get_queue_depth, etc.
+```
 
 #### Phoenix Route Introspection (Issue #14) - Phase 3 Complete!
 - New `expose_routes/1` macro to auto-generate MCP tools from Phoenix router
@@ -36,6 +61,18 @@ expose_routes MyAppWeb.Router,
   namespace: :api,
   methods: ["GET", "POST"]
 ```
+
+### Testing
+- **223 tests** (up from 193)
+- **30 new tests**: 13 for Oban bridge, 17 for route introspection
+- Full integration tested with sweetcorn Phoenix app including:
+  - Oban job insertion, retry, and cancellation via MCP tools
+  - Route tool execution through Phoenix controllers
+  - All authorization strategies working with new features
+
+### Issues Closed
+- [#15](https://github.com/GustavoZiaugra/ectomancer/issues/15) - Create optional Oban bridge for job queue management
+- [#14](https://github.com/GustavoZiaugra/ectomancer/issues/14) - Implement Phoenix route introspection for MCP tools
 
 ## [0.1.0-rc.3] - 2026-03-18
 
@@ -177,7 +214,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v0.1.0-rc.4...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v1.0.0
 [0.1.0-rc.4]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.4
 [0.1.0-rc.3]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.3
 [0.1.0-rc.2]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and p
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 0.1.0-rc.4"}
+    {:ectomancer, "~> 1.0"}
   ]
 end
 ```
@@ -365,7 +365,12 @@ This project is in active development.
 - ✅ Read-only mode for schemas
 - ✅ Ecto changeset error mapping to MCP error responses
 
-Current version: 0.1.0-rc.4
+**Phase 3 (Power Features) is complete**, including:
+- ✅ Phoenix route introspection
+- ✅ Optional Oban bridge for job queue management
+- ✅ Full production readiness
+
+Current version: 1.0.0
 
 ## License
 

--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -92,7 +92,7 @@ defmodule Ectomancer do
   Returns the version of Ectomancer.
   """
   def version do
-    "0.1.0"
+    "1.0.0"
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "0.1.0-rc.4"
+  @version "1.0.0"
 
   def project do
     [
@@ -49,8 +49,13 @@ defmodule Ectomancer.MixProject do
       source_ref: "v#{@version}",
       groups_for_modules: [
         Core: [Ectomancer, Ectomancer.Tool, Ectomancer.Expose],
-        Integration: [Ectomancer.Plug, Ectomancer.Repo],
-        Utilities: [Ectomancer.SQLTool, Ectomancer.SchemaBuilder, Ectomancer.SchemaIntrospection]
+        Integration: [
+          Ectomancer.Plug,
+          Ectomancer.Repo,
+          Ectomancer.RouteIntrospection,
+          Ectomancer.ObanBridge
+        ],
+        Utilities: [Ectomancer.SchemaBuilder, Ectomancer.SchemaIntrospection]
       ]
     ]
   end

--- a/test/ectomancer_test.exs
+++ b/test/ectomancer_test.exs
@@ -3,6 +3,6 @@ defmodule EctomancerTest do
   doctest Ectomancer
 
   test "returns version" do
-    assert Ectomancer.version() == "0.1.0"
+    assert Ectomancer.version() == "1.0.0"
   end
 end


### PR DESCRIPTION
## 🎉 Official v1.0.0 Release - Production Ready!

This PR prepares Ectomancer for its first stable release. All three phases of development are complete!

## Changes

### Version Updates
- **mix.exs**: `0.1.0-rc.4` → `1.0.0`
- **Ectomancer.version/0**: `"0.1.0"` → `"1.0.0"`

### Documentation
- **CHANGELOG.md**: Added comprehensive v1.0.0 release entry documenting all Phase 3 features:
  - Oban bridge with 5 job management tools
  - Phoenix route introspection
  - 223 total tests
  - All issues closed

- **README.md**: 
  - Updated installation to `~> 1.0`
  - Marked Phase 3 as complete in roadmap
  - Updated current version to 1.0.0

### HexDocs Configuration
- Updated `groups_for_modules` to include:
  - `Ectomancer.RouteIntrospection`
  - `Ectomancer.ObanBridge`

## What's in v1.0.0

### Phase 1 - Core (Complete ✅)
- Auto-generated CRUD tools from Ecto schemas
- Phoenix Plug integration
- Actor threading through tool calls

### Phase 2 - Authorization (Complete ✅)
- Authorization system (inline functions, policy modules, action-specific)
- Read-only mode for schemas
- Ecto changeset error mapping

### Phase 3 - Power Features (Complete ✅)
- Phoenix route introspection
- Optional Oban bridge for job queue management

## Checklist

- [x] All 223 tests passing
- [x] Code formatted (`mix format --check-formatted`)
- [x] No credo issues
- [x] HexDocs generated successfully
- [x] CHANGELOG.md updated
- [x] README.md updated
- [x] Version bumped in all locations
- [x] Closes #17

## Post-Merge Steps

After this PR is merged:
1. Tag release: `git tag v1.0.0`
2. Push tag: `git push origin v1.0.0`
3. Create GitHub release
4. Publish to Hex.pm: `mix hex.publish`

🚀 **Ectomancer is production-ready!**