### PR TITLE
chore: Add CLAUDE.md with project instructions and conventions

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,7 @@
+Run all code quality checks for this project in sequence and report the results:
+
+1. `mix compile --warnings-as-errors` — must produce zero warnings
+2. `mix format --check-formatted` — must produce no diff
+3. `mix credo` — must produce zero issues
+
+If any step fails, explain what needs to be fixed and offer to fix it.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,11 @@
+Create a pull request for the current branch following this workflow:
+
+1. Run `/check` to verify code quality — stop and fix any issues before proceeding.
+2. Run `/test` to verify all tests pass — stop and fix any failures before proceeding.
+3. Review `git diff main...HEAD` to understand all changes.
+4. Create the PR with `gh pr create` using:
+   - A short, descriptive title (under 70 characters) with a conventional commit prefix (`feat:`, `fix:`, `refactor:`, `chore:`, etc.)
+   - A body with a brief summary and a markdown test-plan checklist
+   - Do NOT add a `Co-Authored-By` trailer
+
+Return the PR URL when done.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,3 @@
+Run the full test suite with `mix test` and report the results.
+
+If any tests fail, show the failure output and identify the root cause. Do not retry the same failing test without a code change.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mix test*)",
+      "Bash(mix format*)",
+      "Bash(mix credo*)",
+      "Bash(mix compile*)",
+      "Bash(mix deps*)",
+      "Bash(mix dialyzer*)",
+      "Bash(mix docs*)",
+      "Bash(mix hex*)",
+      "Bash(git checkout -b *)",
+      "Bash(git push origin *)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git status*)",
+      "Bash(git add *)",
+      "Bash(git commit*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh api*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mix format"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ ectomancer-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Claude Code local settings (machine-specific, not for sharing)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Ectomancer — Claude Instructions
+
+Ectomancer is an Elixir library that exposes Phoenix/Ecto applications as MCP (Model Context Protocol) servers, making them operable by LLMs with minimal configuration.
+
+## Commands
+
+```bash
+mix test              # run the full test suite
+mix format            # auto-format all source files
+mix credo             # static analysis — must pass with zero warnings
+mix dialyzer          # type checking — run before PRs
+mix docs              # generate documentation
+```
+
+## Code Quality Rules
+
+- **Zero Credo warnings.** All issues reported by `mix credo` must be resolved before committing.
+- **Zero compiler warnings.** `mix compile` must be clean.
+- **Formatter compliance.** Always run `mix format` before committing.
+- Keep cyclomatic complexity ≤ 9. Extract private helpers when a function grows beyond this.
+- Maximum function body nesting depth: 2. Use guard clauses or helper functions to flatten.
+- Prefer `if` over `unless` with an `else` block.
+- Use `Enum.map_join/3` instead of `Enum.map/2 |> Enum.join/2`.
+- Avoid `length/1` for emptiness checks — use `== []` or `Enum.empty?/1`.
+- Aliases must be sorted alphabetically within their group.
+
+## Architecture
+
+| Layer | Modules | Responsibility |
+|---|---|---|
+| DSL | `Ectomancer`, `Ectomancer.Expose`, `Ectomancer.Tool` | Public macros for schema exposure and custom tools |
+| Authorization | `Ectomancer.Authorization`, `Ectomancer.Authorization.Policy` | Inline, policy-module, and action-specific auth |
+| Integration | `Ectomancer.Plug`, `Ectomancer.Repo`, `Ectomancer.ObanBridge` | Phoenix plug, Ecto CRUD, Oban job management |
+| Introspection | `Ectomancer.SchemaIntrospection`, `Ectomancer.SchemaBuilder`, `Ectomancer.RouteIntrospection` | Compile-time metadata extraction and JSON schema generation |
+| Installer | `Ectomancer.Installer.*`, `Mix.Tasks.Ectomancer.Setup` | Interactive setup, schema discovery, config file patching |
+
+Optional dependencies (Phoenix, Ecto, Oban, Plug) are declared as optional in `mix.exs` and must be guarded accordingly.
+
+## Workflow
+
+- All changes go through a PR — **never push directly to `main`**.
+- Branch naming: `feat/`, `fix/`, `refactor/`, `chore/` prefixes.
+- Run `mix test && mix credo && mix format` locally before opening a PR.
+- Do not add `Co-Authored-By` trailers to commits.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to give Claude context about the project when working on it
- Covers development commands, code quality rules (Credo, formatter, complexity limits), architecture overview, and workflow conventions
- Explicitly instructs Claude not to push directly to `main` and not to add co-author trailers to commits

## Test plan

- [ ] No code changes — review content for accuracy and completeness