### PR TITLE
fix: Resolve all Dialyzer warnings in installer modules

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,7 @@
+Run all code quality checks for this project in sequence and report the results:
+
+1. `mix compile --warnings-as-errors` — must produce zero warnings
+2. `mix format --check-formatted` — must produce no diff
+3. `mix credo` — must produce zero issues
+
+If any step fails, explain what needs to be fixed and offer to fix it.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,11 @@
+Create a pull request for the current branch following this workflow:
+
+1. Run `/check` to verify code quality — stop and fix any issues before proceeding.
+2. Run `/test` to verify all tests pass — stop and fix any failures before proceeding.
+3. Review `git diff main...HEAD` to understand all changes.
+4. Create the PR with `gh pr create` using:
+   - A short, descriptive title (under 70 characters) with a conventional commit prefix (`feat:`, `fix:`, `refactor:`, `chore:`, etc.)
+   - A body with a brief summary and a markdown test-plan checklist
+   - Do NOT add a `Co-Authored-By` trailer
+
+Return the PR URL when done.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,3 @@
+Run the full test suite with `mix test` and report the results.
+
+If any tests fail, show the failure output and identify the root cause. Do not retry the same failing test without a code change.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,38 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mix test*)",
+      "Bash(mix format*)",
+      "Bash(mix credo*)",
+      "Bash(mix compile*)",
+      "Bash(mix deps*)",
+      "Bash(mix dialyzer*)",
+      "Bash(mix docs*)",
+      "Bash(mix hex*)",
+      "Bash(git checkout -b *)",
+      "Bash(git push origin *)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git status*)",
+      "Bash(git add *)",
+      "Bash(git commit*)",
+      "Bash(gh pr create*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr list*)",
+      "Bash(gh api*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mix format"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ ectomancer-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Claude Code local settings (machine-specific, not for sharing)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Ectomancer — Claude Instructions
+
+Ectomancer is an Elixir library that exposes Phoenix/Ecto applications as MCP (Model Context Protocol) servers, making them operable by LLMs with minimal configuration.
+
+## Commands
+
+```bash
+mix test              # run the full test suite
+mix format            # auto-format all source files
+mix credo             # static analysis — must pass with zero warnings
+mix dialyzer          # type checking — run before PRs
+mix docs              # generate documentation
+```
+
+## Code Quality Rules
+
+- **Zero Credo warnings.** All issues reported by `mix credo` must be resolved before committing.
+- **Zero compiler warnings.** `mix compile` must be clean.
+- **Formatter compliance.** Always run `mix format` before committing.
+- Keep cyclomatic complexity ≤ 9. Extract private helpers when a function grows beyond this.
+- Maximum function body nesting depth: 2. Use guard clauses or helper functions to flatten.
+- Prefer `if` over `unless` with an `else` block.
+- Use `Enum.map_join/3` instead of `Enum.map/2 |> Enum.join/2`.
+- Avoid `length/1` for emptiness checks — use `== []` or `Enum.empty?/1`.
+- Aliases must be sorted alphabetically within their group.
+
+## Architecture
+
+| Layer | Modules | Responsibility |
+|---|---|---|
+| DSL | `Ectomancer`, `Ectomancer.Expose`, `Ectomancer.Tool` | Public macros for schema exposure and custom tools |
+| Authorization | `Ectomancer.Authorization`, `Ectomancer.Authorization.Policy` | Inline, policy-module, and action-specific auth |
+| Integration | `Ectomancer.Plug`, `Ectomancer.Repo`, `Ectomancer.ObanBridge` | Phoenix plug, Ecto CRUD, Oban job management |
+| Introspection | `Ectomancer.SchemaIntrospection`, `Ectomancer.SchemaBuilder`, `Ectomancer.RouteIntrospection` | Compile-time metadata extraction and JSON schema generation |
+| Installer | `Ectomancer.Installer.*`, `Mix.Tasks.Ectomancer.Setup` | Interactive setup, schema discovery, config file patching |
+
+Optional dependencies (Phoenix, Ecto, Oban, Plug) are declared as optional in `mix.exs` and must be guarded accordingly.
+
+## Workflow
+
+- All changes go through a PR — **never push directly to `main`**.
+- Branch naming: `feat/`, `fix/`, `refactor/`, `chore/` prefixes.
+- Run `mix test && mix credo && mix format` locally before opening a PR.
+- Do not add `Co-Authored-By` trailers to commits.

--- a/lib/ectomancer/installer/config_updater.ex
+++ b/lib/ectomancer/installer/config_updater.ex
@@ -36,7 +36,7 @@ defmodule Ectomancer.Installer.ConfigUpdater do
     %{
       mix_exs: update_mix_exs(mix_path),
       config_exs: update_config_exs(config_path),
-      router_exs: router_path && update_router_exs(router_path)
+      router_exs: if(router_path, do: update_router_exs(router_path))
     }
   end
 

--- a/lib/ectomancer/installer/schema_discovery.ex
+++ b/lib/ectomancer/installer/schema_discovery.ex
@@ -134,8 +134,9 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
     with {:ok, content} <- File.read(file_path),
          {:ok, ast} <- Code.string_to_quoted(content) do
       case ast do
-        {:defmodule, {module_name, _module_meta}, _env} ->
-          module_name
+        {:defmodule, _meta, [{:__aliases__, _, module_parts}, _]} ->
+          module_parts
+          |> Module.concat()
           |> extract_module_info(file_path)
           |> case do
             nil -> []
@@ -150,18 +151,10 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
     end
   end
 
-  defp extract_module_info(module_name, file_path) do
-    full_module_name = module_name
-
-    try do
-      module = Module.concat(full_module_name)
-
-      unless function_exported?(module, :__schema__, 1) do
-        nil
-      end
-
+  defp extract_module_info(module, file_path) do
+    if function_exported?(module, :__schema__, 1) do
       table = extract_table_from_file(file_path)
-      context = extract_context(full_module_name)
+      context = extract_context(module)
 
       associations =
         try do
@@ -184,9 +177,9 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
         associations: associations,
         writable_fields: writable_fields
       }
-    rescue
-      _ -> nil
     end
+  rescue
+    _ -> nil
   end
 
   defp extract_table_from_file(file_path) do

--- a/lib/mix/tasks/ectomancer.setup.ex
+++ b/lib/mix/tasks/ectomancer.setup.ex
@@ -101,11 +101,11 @@ defmodule Ectomancer.Mix.Tasks.Ectomancer.Setup do
 
     Mix.shell().info("\n⚙️  Updating configuration files...")
 
-    config = %{
+    config = [
       mix_path: "mix.exs",
       config_path: "config/config.exs",
       router_path: find_router_path()
-    }
+    ]
 
     results = ConfigUpdater.update_files(config)
     print_config_update_results(results)

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Ectomancer.MixProject do
       package: package(),
       docs: docs(),
       source_url: @source_url,
-      homepage_url: @source_url
+      homepage_url: @source_url,
+      dialyzer: [plt_add_apps: [:mix]]
     ]
   end
 


### PR DESCRIPTION
## Summary

- **Add `:mix` to Dialyzer PLT** (`mix.exs`) — resolves `unknown_function`, `callback_info_missing`, `no_return`, and `unused_fun` warnings for all `Mix.*` calls in the setup task
- **Fix defmodule AST pattern** (`schema_discovery.ex`) — the pattern `{:defmodule, {name, meta}, env}` never matched `Code.string_to_quoted` output; corrected to `{:defmodule, _meta, [{:__aliases__, _, parts}, _]}`
- **Fix non-guarding `unless`** (`schema_discovery.ex`) — `unless` without else doesn't return early in Elixir; replaced with `if` to properly skip non-schema modules in file discovery
- **Remove redundant `Module.concat/1` on atom** (`schema_discovery.ex`) — `Module.concat/1` expects a list, not an atom; the module was already resolved upstream
- **Fix map/keyword mismatch** (`ectomancer.setup.ex`) — `update_files/1` expects a keyword list but was called with a map
- **Replace `&&` with `if/2`** (`config_updater.ex`) — narrows type from `false | nil | result` to `nil | result`, satisfying Dialyzer

## Verification

- `mix dialyzer` — 0 errors (was 14)
- `mix test --warnings-as-errors` — 255 tests, 0 failures
- `mix credo --strict` — 0 issues
- `mix compile --warnings-as-errors` — clean

## Test plan

- [ ] CI passes on all 3 matrix jobs (OTP 26.2, 27.3, 28.1)
- [ ] `mix dialyzer --halt-exit-status` exits 0 on the lint matrix job