### PR TITLE
fix: Resolve critical bugs in setup tool

### DIFF
--- a/lib/ectomancer/installer/schema_discovery.ex
+++ b/lib/ectomancer/installer/schema_discovery.ex
@@ -49,10 +49,14 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
   """
   @spec module_introspection() :: list(map())
   def module_introspection do
+    app_prefix = detect_app_module_prefix()
+
     modules =
       :code.all_loaded()
       |> Enum.map(&elem(&1, 0))
-      |> Enum.filter(&ecto_schema_module?/1)
+      |> Enum.filter(fn mod ->
+        ecto_schema_module?(mod) && app_module?(mod, app_prefix)
+      end)
 
     Enum.map(modules, fn module ->
       schema_info = analyze_module(module)
@@ -76,17 +80,13 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
   def file_discovery do
     lib_path = Path.join([File.cwd!(), "lib"])
 
-    unless File.exists?(lib_path) do
-      []
-    end
-
-    schema_files =
+    if File.exists?(lib_path) do
       Path.wildcard(Path.join([lib_path, "**/*.ex"]))
       |> Enum.filter(&contains_ecto_schema?/1)
-
-    Enum.flat_map(schema_files, fn file_path ->
-      extract_schemas_from_file(file_path)
-    end)
+      |> Enum.flat_map(&extract_schemas_from_file/1)
+    else
+      []
+    end
   end
 
   @doc """
@@ -112,6 +112,28 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
   end
 
   # Private functions
+
+  defp detect_app_module_prefix do
+    case File.read("mix.exs") do
+      {:ok, content} ->
+        case Regex.run(~r/app:\s*:(\w+)/, content) do
+          [_, app_name] -> Macro.camelize(app_name)
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp app_module?(_module, nil), do: true
+
+  defp app_module?(module, prefix) do
+    module
+    |> Module.split()
+    |> List.first()
+    |> Kernel.==(prefix)
+  end
 
   defp ecto_schema_module?(module) do
     Code.ensure_loaded?(module) and
@@ -152,6 +174,8 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
   end
 
   defp extract_module_info(module, file_path) do
+    Code.ensure_loaded(module)
+
     if function_exported?(module, :__schema__, 1) do
       table = extract_table_from_file(file_path)
       context = extract_context(module)
@@ -192,8 +216,10 @@ defmodule Ectomancer.Installer.SchemaDiscovery do
         table_name
 
       _ ->
-        module_name = file_path |> Path.basename() |> String.replace(".ex", "")
-        Macro.underscore(module_name) |> String.replace("_", "")
+        file_path
+        |> Path.basename(".ex")
+        |> Macro.underscore()
+        |> Kernel.<>("s")
     end
   end
 

--- a/lib/ectomancer/installer/template_renderer.ex
+++ b/lib/ectomancer/installer/template_renderer.ex
@@ -20,6 +20,7 @@ defmodule Ectomancer.Installer.TemplateRenderer do
       * `:namespace` - Tool namespace (default: nil)
       * `:include_oban` - Whether to include Oban bridge
       * `:output_path` - Where to save the file
+      * `:module_name` - Module name for the generated MCP module (default: "MyApp.MCP")
 
   ## Returns
 
@@ -34,6 +35,7 @@ defmodule Ectomancer.Installer.TemplateRenderer do
     namespace = Keyword.get(opts, :namespace, nil)
     include_oban = Keyword.get(opts, :include_oban, false)
     output_path = Keyword.get(opts, :output_path, "lib/my_app/mcp.ex")
+    module_name = Keyword.get(opts, :module_name, "MyApp.MCP")
 
     existing_content =
       if File.exists?(output_path) do
@@ -43,11 +45,14 @@ defmodule Ectomancer.Installer.TemplateRenderer do
       end
 
     generated_content =
-      generate_mcp_module_content(schemas, mcp_name, mcp_version, namespace, include_oban)
+      generate_mcp_module_content(schemas, mcp_name, mcp_version, namespace, include_oban,
+        module_name: module_name
+      )
 
     if generated_content == existing_content do
       :not_modified
     else
+      File.mkdir_p!(Path.dirname(output_path))
       File.write!(output_path, generated_content)
       {:ok, "Generated MCP module at #{output_path}"}
     end
@@ -93,105 +98,59 @@ defmodule Ectomancer.Installer.TemplateRenderer do
   @doc """
   Generates complete MCP module content.
   """
-  @spec generate_mcp_module_content(list(map()), String.t(), String.t(), atom() | nil, boolean()) ::
-          String.t()
-  def generate_mcp_module_content(schemas, mcp_name, mcp_version, namespace, include_oban) do
-    expose_annotations = Enum.map_join(schemas, "\n", &generate_expose_annotation/1)
+  @spec generate_mcp_module_content(
+          list(map()),
+          String.t(),
+          String.t(),
+          String.t() | nil,
+          boolean(),
+          keyword()
+        ) :: String.t()
+  def generate_mcp_module_content(
+        schemas,
+        mcp_name,
+        mcp_version,
+        namespace,
+        include_oban,
+        opts \\ []
+      ) do
+    module_name = Keyword.get(opts, :module_name, "MyApp.MCP")
+    expose_lines = Enum.map_join(schemas, "\n\n", &generate_expose_line(&1, namespace))
 
-    example_tools =
-      case Enum.at(schemas, 0) do
-        nil -> ""
-        schema -> generate_example_tools(schema, namespace)
-      end
-
-    oban_section =
+    oban_line =
       if include_oban do
-        """
-
-        # Oban job management tools
-        expose_oban_jobs
-        """
+        "\n\n  expose_oban_jobs"
       else
         ""
       end
 
     """
-    defmodule MyApp.MCP do
+    defmodule #{module_name} do
       use Ectomancer,
         name: "#{mcp_name}",
         version: "#{mcp_version}"
 
-      # Expose Ecto schemas as MCP tools
-      #{expose_annotations}
-
-      #{example_tools}
-
-      #{oban_section}
+    #{expose_lines}#{oban_line}
     end
     """
   end
 
-  defp generate_expose_annotation(schema) do
-    module = schema.module
+  defp generate_expose_line(schema, namespace) do
     actions = determine_actions(schema)
 
-    """
-      #{generate_tool_definition(module)}
-      expose #{inspect(module)},
-        actions: #{actions}
-    """
+    namespace_opt =
+      if namespace && namespace != "",
+        do: ",\n    namespace: :#{Macro.underscore(namespace)}",
+        else: ""
+
+    "  expose #{inspect(schema.module)},\n    actions: #{actions}#{namespace_opt}"
   end
 
   defp determine_actions(schema) do
-    writable = Enum.count(schema.writable_fields)
-
-    if writable > 0 do
-      "[list, get, create, update, delete]"
+    if Enum.any?(schema.writable_fields) do
+      "[:list, :get, :create, :update, :destroy]"
     else
-      "[list, get]"
+      "[:list, :get]"
     end
-  end
-
-  defp generate_tool_definition(module) do
-    table_name =
-      module
-      |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
-
-    tool_name = :"#{table_name}_#{String.to_atom("list")}"
-
-    """
-      # Auto-generated tool for #{inspect(module)}
-      #{tool_name} = :#{table_name}_list
-    """
-  end
-
-  defp generate_example_tools(schema, namespace) do
-    module = schema.module
-    table_name = schema.table || "records"
-    indent = if namespace, do: "  ", else: ""
-    body_indent = if namespace, do: "    ", else: "  "
-    handle_close = if namespace, do: "  ", else: "end"
-
-    """
-
-      # Example custom tool for #{inspect(module)}
-      #{indent}tool :#{format_tool_name(module)} do
-        #{indent}description "List #{table_name}"
-        #{indent}authorize :public
-        #{indent}handle fn _params, _actor ->
-        #{body_indent}{:ok, []}
-        #{handle_close}
-      end
-    """
-  end
-
-  defp format_tool_name(module) do
-    module
-    |> Module.split()
-    |> List.last()
-    |> Macro.underscore()
-    |> String.to_atom()
   end
 end

--- a/lib/mix/tasks/ectomancer/setup.ex
+++ b/lib/mix/tasks/ectomancer/setup.ex
@@ -52,7 +52,10 @@ defmodule Mix.Tasks.Ectomancer.Setup do
 
   @impl Mix.Task
   def run(_args) do
+    Mix.Task.run("compile")
     Mix.shell().info("\n🚀 Setting up Ectomancer...")
+
+    app_name = detect_app_name()
 
     check_dependencies!()
     schemas = discover_schemas!()
@@ -62,8 +65,8 @@ defmodule Mix.Tasks.Ectomancer.Setup do
     include_oban = if :oban in optional_deps, do: prompt_for_oban_bridge(), else: false
     namespace = prompt_for_namespace()
 
-    mcp_path = generate_mcp_module(selected_schemas, include_oban, namespace)
-    update_configuration_files()
+    mcp_path = generate_mcp_module(selected_schemas, include_oban, namespace, app_name)
+    update_configuration_files(app_name)
     print_summary(selected_schemas, include_oban, namespace, mcp_path)
 
     :ok
@@ -118,16 +121,18 @@ defmodule Mix.Tasks.Ectomancer.Setup do
     selected_schemas
   end
 
-  defp generate_mcp_module(selected_schemas, include_oban, namespace) do
+  defp generate_mcp_module(selected_schemas, include_oban, namespace, app_name) do
     Mix.shell().info("\n📝 Generating MCP module...")
 
-    mcp_path = get_mcp_module_path()
+    mcp_path = get_mcp_module_path(app_name)
+    module_name = mcp_module_name(app_name)
 
     case TemplateRenderer.generate_mcp_module(
            schemas: selected_schemas,
            output_path: mcp_path,
            include_oban: include_oban,
-           namespace: namespace
+           namespace: namespace,
+           module_name: module_name
          ) do
       {:ok, message} ->
         Mix.shell().info("   ✓ #{message}")
@@ -139,13 +144,13 @@ defmodule Mix.Tasks.Ectomancer.Setup do
     mcp_path
   end
 
-  defp update_configuration_files do
+  defp update_configuration_files(app_name) do
     Mix.shell().info("\n⚙️  Updating configuration files...")
 
     config = [
       mix_path: "mix.exs",
       config_path: "config/config.exs",
-      router_path: find_router_path()
+      router_path: find_router_path(app_name)
     ]
 
     results = ConfigUpdater.update_files(config)
@@ -153,12 +158,14 @@ defmodule Mix.Tasks.Ectomancer.Setup do
   end
 
   defp print_summary(selected_schemas, include_oban, namespace, mcp_path) do
+    tool_count = count_tools(selected_schemas)
+
     Mix.shell().info("\n✅ Setup complete!")
     Mix.shell().info("\n📋 Summary:")
     Mix.shell().info("   • Added #{length(selected_schemas)} schema(s)")
-    Mix.shell().info("   • Generated #{length(selected_schemas) * 2} tool(s)")
+    Mix.shell().info("   • Generated #{tool_count} tool(s)")
     Mix.shell().info("   • Oban bridge: #{if include_oban, do: "enabled", else: "disabled"}")
-    Mix.shell().info("   • Namespace: #{if namespace == "", do: "none", else: namespace}")
+    Mix.shell().info("   • Namespace: #{namespace || "none"}")
     Mix.shell().info("   • MCP module: #{Path.basename(mcp_path)}")
 
     Mix.shell().info("\n📝 Next steps:")
@@ -184,7 +191,7 @@ defmodule Mix.Tasks.Ectomancer.Setup do
     schemas
     |> Enum.with_index(1)
     |> Enum.each(fn {schema, index} ->
-      Mix.shell().info("   [#{index}] #{schema.module}")
+      Mix.shell().info("   [#{index}] #{inspect(schema.module)}")
     end)
 
     Mix.shell().info("")
@@ -192,7 +199,7 @@ defmodule Mix.Tasks.Ectomancer.Setup do
     selections = prompt_for_selections(schemas)
 
     Enum.map(selections, fn index ->
-      schemas |> Enum.at(index - 1)
+      Enum.at(schemas, index)
     end)
   end
 
@@ -235,16 +242,35 @@ defmodule Mix.Tasks.Ectomancer.Setup do
   defp prompt_for_namespace do
     Mix.shell().info("? Tool namespace? (e.g., 'MyApp', leave empty for none)")
 
-    get_input() |> String.trim()
+    case get_input() |> String.trim() do
+      "" -> nil
+      value -> value
+    end
   end
 
   defp get_input do
-    Mix.shell().input("> ")
+    case IO.gets("> ") do
+      :eof -> ""
+      {:error, _} -> ""
+      input -> input
+    end
   end
 
-  defp get_mcp_module_path do
-    app_name = detect_app_name() || "my_app"
-    "lib/#{app_name}/mcp.ex"
+  defp count_tools(schemas) do
+    Enum.reduce(schemas, 0, fn schema, acc ->
+      if Enum.any?(schema.writable_fields), do: acc + 5, else: acc + 2
+    end)
+  end
+
+  defp get_mcp_module_path(app_name) do
+    "lib/#{app_name || "my_app"}/mcp.ex"
+  end
+
+  defp mcp_module_name(app_name) do
+    case app_name do
+      nil -> "MyApp.MCP"
+      name -> "#{Macro.camelize(name)}.MCP"
+    end
   end
 
   defp detect_app_name do
@@ -260,25 +286,15 @@ defmodule Mix.Tasks.Ectomancer.Setup do
     end
   end
 
-  defp find_router_path do
-    possible_paths = [
-      "lib/my_app_web/router.ex",
-      "lib/my_app/router.ex"
-    ]
-
-    app_name = detect_app_name()
-
-    paths =
-      if app_name do
-        [
-          "lib/#{app_name}_web/router.ex",
-          "lib/#{app_name}/router.ex"
-          | possible_paths
-        ]
-      else
-        possible_paths
-      end
-
-    Enum.find(paths, &File.exists?/1)
+  defp find_router_path(app_name) do
+    if app_name do
+      [
+        "lib/#{app_name}_web/router.ex",
+        "lib/#{app_name}/router.ex"
+      ]
+    else
+      []
+    end
+    |> Enum.find(&File.exists?/1)
   end
 end


### PR DESCRIPTION
## Summary

- Fix runtime crash: `Mix.shell().input/1` doesn't exist, replaced with `IO.gets/1` with `:eof` handling
- Fix schema discovery: modules weren't loaded after compile — added `Mix.Task.run("compile")` and `Code.ensure_loaded/1`
- Fix double index subtraction in schema selection causing wrong schema to be picked
- Fix template renderer: bare identifier actions (`list`) → atom actions (`:list`), `delete` → `:destroy`, hardcoded `MyApp.MCP` → derived from app name, removed broken example tool template
- Fix empty namespace producing invalid `namespace: :` syntax
- Fix tool count summary (was `schemas * 2`, now computed: 5 for writable, 2 for read-only)
- Fix `file_discovery` early return (`unless` block didn't return), table name fallback stripping underscores
- Filter dependency schemas out of `module_introspection` results
- Consolidate redundant `detect_app_name` disk reads, add `File.mkdir_p!` before write

## Test plan

- [x] `mix test` — 260 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [x] `mix credo` — no issues
- [x] `mix dialyzer` — 0 errors
- [x] `mix ectomancer.setup` in test_ecto_app — discovers 3 schemas, generates valid module, compiles cleanly