### PR TITLE
chore: Prepare v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-23
+
 ### Added
 - Interactive setup tool (`mix ectomancer.setup`) for automatic project configuration
-- Schema discovery module to automatically find Ecto schemas in your project
-- Config updater for automatic updates to mix.exs, config.exs, and router files
+  - Auto-discovers Ecto schemas via module introspection and file scanning
+  - Prompts for schema selection, Oban bridge, and tool namespace
+  - Generates MCP module with proper `expose` declarations
+  - Updates mix.exs, config.exs, and router files automatically
+  - Derives module name from app name (e.g., `TestEctoApp.MCP`)
+- Schema discovery module (`Ectomancer.Installer.SchemaDiscovery`) with dual discovery strategy
+- Config updater (`Ectomancer.Installer.ConfigUpdater`) for idempotent file patching
+- Dependency checker (`Ectomancer.Installer.DependencyChecker`) for required/optional dep validation
+- Template renderer (`Ectomancer.Installer.TemplateRenderer`) for MCP module generation
+- Igniter installer stub (`Ectomancer.Igniter`)
+
+### Testing
+- **260 tests** (up from 223), all passing
+- Full integration tests for the setup tool workflow
 
 ## [1.0.0] - 2026-03-29
 
@@ -219,7 +233,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v1.0.0
 [0.1.0-rc.4]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.4
 [0.1.0-rc.3]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and p
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 1.0"}
+    {:ectomancer, "~> 1.1"}
   ]
 end
 ```
@@ -32,7 +32,58 @@ Run the interactive setup wizard that auto-discovers your schemas:
 mix ectomancer.setup
 ```
 
-This will scan for Ecto schemas, prompt you to select which to expose, ask about optional features, generate the MCP module, and update config files automatically.
+The wizard will:
+
+1. **Check dependencies** — verifies `ecto` and `plug` are present
+2. **Discover schemas** — scans your project for Ecto schemas via module introspection and file scanning
+3. **Prompt for selection** — lets you choose which schemas to expose as MCP tools
+4. **Configure features** — asks about Oban bridge and tool namespacing
+5. **Generate files** — creates the MCP module and patches `mix.exs`, `config.exs`, and your router
+
+Example session:
+
+```
+$ mix ectomancer.setup
+
+🚀 Setting up Ectomancer...
+   ✓ Required dependencies found
+
+🔍 Scanning for Ecto schemas...
+
+📦 Found 3 schema(s):
+   ✓ MyApp.Accounts.User
+   ✓ MyApp.Blog.Post
+   ✓ MyApp.Blog.Comment
+
+? Select schemas to expose (comma-separated numbers, e.g., 1,2,3)
+> 1,2,3
+? Tool namespace? (e.g., 'MyApp', leave empty for none)
+>
+
+📝 Generating MCP module...
+   ✓ Generated MCP module at lib/my_app/mcp.ex
+
+✅ Setup complete!
+```
+
+This generates a ready-to-use MCP module:
+
+```elixir
+defmodule MyApp.MCP do
+  use Ectomancer,
+    name: "my-app-mcp",
+    version: "1.0.0"
+
+  expose MyApp.Accounts.User,
+    actions: [:list, :get, :create, :update, :destroy]
+
+  expose MyApp.Blog.Post,
+    actions: [:list, :get, :create, :update, :destroy]
+
+  expose MyApp.Blog.Comment,
+    actions: [:list, :get, :create, :update, :destroy]
+end
+```
 
 ### Option 2: Manual Setup
 
@@ -349,10 +400,11 @@ Once connected, Claude can:
 
 Ectomancer includes comprehensive test coverage:
 
-- **189 tests** covering all features
+- **260 tests** covering all features
 - **35 authorization-specific tests**
 - **16 changeset error mapping tests**
 - **6 read-only mode tests**
+- **37 installer/setup tests** (unit + integration)
 - Full integration tested with Phoenix apps
 - Zero compiler warnings
 - Full Credo and Dialyzer compliance
@@ -383,7 +435,7 @@ This project is in active development.
 - ✅ Read-only mode for schemas
 - ✅ Ecto changeset error mapping to MCP error responses
 
-Current version: 1.0.0
+Current version: 1.1.0
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "1.0.0"
+  @version "1.1.0"
 
   def project do
     [
@@ -32,7 +32,7 @@ defmodule Ectomancer.MixProject do
   defp package do
     [
       name: :ectomancer,
-      files: ["lib", "mix.exs", "README.md", "LICENSE", "CHANGELOG.md"],
+      files: ["lib", "priv", "mix.exs", "README.md", "LICENSE", "CHANGELOG.md"],
       maintainers: ["Gustavo Ziaugra"],
       licenses: ["MIT"],
       links: %{
@@ -56,7 +56,13 @@ defmodule Ectomancer.MixProject do
           Ectomancer.RouteIntrospection,
           Ectomancer.ObanBridge
         ],
-        Utilities: [Ectomancer.SchemaBuilder, Ectomancer.SchemaIntrospection]
+        Utilities: [Ectomancer.SchemaBuilder, Ectomancer.SchemaIntrospection],
+        Installer: [
+          Ectomancer.Installer.ConfigUpdater,
+          Ectomancer.Installer.DependencyChecker,
+          Ectomancer.Installer.SchemaDiscovery,
+          Ectomancer.Installer.TemplateRenderer
+        ]
       ]
     ]
   end


### PR DESCRIPTION
## Summary

- Bump version to `1.1.0` in `mix.exs`
- Update CHANGELOG with full v1.1.0 entry (interactive setup tool, schema discovery, config updater, dependency checker, template renderer, 260 tests)
- Expand README Quick Start with detailed `mix ectomancer.setup` walkthrough — step-by-step wizard description, example session output, and generated MCP module sample
- Update installation dep to `~> 1.1`, test count to 260, current version to 1.1.0
- Add `priv` to package files and installer modules to docs groups

## After merge

```bash
git tag v1.1.0
git push origin v1.1.0
mix hex.publish
```

## Test plan

- [x] `mix test` — 260 tests, 0 failures
- [x] `mix format` — clean
- [x] `mix credo` — no issues
- [x] `mix dialyzer` — 0 errors