### PR TITLE
feat: association preloading for related records (closes #60)

### DIFF
--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -30,6 +30,7 @@ if Code.ensure_loaded?(Ecto) do
       * `:as` - Alternative name for the resource (e.g., `:admin_users` → `list_admin_users`)
       * `:readonly` - Enable read-only mode (disables `:create`, `:update`, `:destroy`)
       * `:authorize` - Authorization configuration (function, policy module, or action-specific rules)
+      * `:preload` - Ecto associations to eager-load on `:list` and `:get` results
 
     ## Generated Tools
 
@@ -209,7 +210,8 @@ if Code.ensure_loaded?(Ecto) do
         namespace: opts[:namespace],
         introspection: introspection,
         authorization: auth_config,
-        readonly: readonly
+        readonly: readonly,
+        preload: Keyword.get(opts, :preload, [])
       }
     end
 
@@ -355,9 +357,19 @@ if Code.ensure_loaded?(Ecto) do
       auth_block = generate_authorization_block(action, config)
 
       handler =
-        quote do
-          fn params, _actor ->
-            Ectomancer.Repo.unquote(action)(unquote(config.schema), params)
+        if action in [:list, :get] and config.preload != [] do
+          quote do
+            fn params, _actor ->
+              Ectomancer.Repo.unquote(action)(unquote(config.schema), params,
+                preload: unquote(config.preload)
+              )
+            end
+          end
+        else
+          quote do
+            fn params, _actor ->
+              Ectomancer.Repo.unquote(action)(unquote(config.schema), params)
+            end
           end
         end
 

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -72,7 +72,8 @@ if Code.ensure_loaded?(Ecto) do
           |> apply_ordering(meta_params, introspection.fields)
           |> apply_pagination(meta_params, opts)
 
-        {:ok, repo.all(query)}
+        results = repo.all(query)
+        {:ok, maybe_preload(repo, results, opts)}
       end)
     end
 
@@ -83,16 +84,23 @@ if Code.ensure_loaded?(Ecto) do
 
       * `schema_module` - The Ecto schema module
       * `params` - Map containing the primary key value
+      * `opts` - Options including `:preload` for eager-loading associations
 
     ## Examples
 
         get(MyApp.Accounts.User, %{"id" => 123})
+        get(MyApp.Accounts.User, %{"id" => 123}, preload: [:posts, :comments])
     """
-    @spec get(module(), map()) :: {:ok, struct() | nil} | {:error, any()}
-    def get(schema_module, params) do
+    @spec get(module(), map(), keyword()) :: {:ok, struct() | nil} | {:error, any()}
+    def get(schema_module, params, opts \\ []) do
       with {:ok, repo} <- get_repo(),
            {:ok, pk_values} <- extract_pk_for_get(schema_module, params) do
-        fetch_single_record(repo, schema_module, pk_values)
+        result = fetch_single_record(repo, schema_module, pk_values)
+
+        case result do
+          {:ok, record} -> {:ok, maybe_preload(repo, record, opts)}
+          error -> error
+        end
       end
     rescue
       e -> {:error, "GET failed: #{Exception.message(e)}"}
@@ -462,6 +470,22 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp parse_int(_), do: nil
+
+    defp maybe_preload(_repo, record, _opts) when is_nil(record), do: nil
+
+    defp maybe_preload(repo, record, opts) when not is_list(record) do
+      case Keyword.get(opts, :preload) do
+        nil -> record
+        preloads -> repo.preload(record, preloads)
+      end
+    end
+
+    defp maybe_preload(repo, records, opts) when is_list(records) do
+      case Keyword.get(opts, :preload) do
+        nil -> records
+        preloads -> repo.preload(records, preloads)
+      end
+    end
 
     defp extract_primary_key(_params, [], _field_types), do: {:error, :no_primary_key}
 

--- a/test/ectomancer/preload_test.exs
+++ b/test/ectomancer/preload_test.exs
@@ -9,10 +9,10 @@ defmodule Ectomancer.PreloadTest do
     use Ecto.Schema
 
     schema "preload_posts" do
-      field :title, :string
-      field :body, :string
-      field :views, :integer
-      has_many :comments, Ectomancer.PreloadTest.Comment, foreign_key: :post_id
+      field(:title, :string)
+      field(:body, :string)
+      field(:views, :integer)
+      has_many(:comments, Ectomancer.PreloadTest.Comment, foreign_key: :post_id)
       timestamps()
     end
   end
@@ -21,8 +21,8 @@ defmodule Ectomancer.PreloadTest do
     use Ecto.Schema
 
     schema "preload_comments" do
-      field :body, :string
-      belongs_to :post, Ectomancer.PreloadTest.Post
+      field(:body, :string)
+      belongs_to(:post, Ectomancer.PreloadTest.Post)
       timestamps()
     end
   end
@@ -80,9 +80,10 @@ defmodule Ectomancer.PreloadTest do
       defmodule PreloadTestMCP do
         use Ectomancer
 
-        expose Ectomancer.PreloadTest.Post,
+        expose(Ectomancer.PreloadTest.Post,
           actions: [:list, :get],
           preload: [:comments]
+        )
       end
 
       assert {:module, _} = Code.ensure_loaded(PreloadTestMCP.Tool.ListPosts)

--- a/test/ectomancer/preload_test.exs
+++ b/test/ectomancer/preload_test.exs
@@ -1,0 +1,92 @@
+defmodule Ectomancer.PreloadTest do
+  use Ectomancer.DataCase,
+    schemas: [Ectomancer.PreloadTest.Post, Ectomancer.PreloadTest.Comment]
+
+  alias Ectomancer.Repo
+  alias Ectomancer.TestRepo
+
+  defmodule Post do
+    use Ecto.Schema
+
+    schema "preload_posts" do
+      field :title, :string
+      field :body, :string
+      field :views, :integer
+      has_many :comments, Ectomancer.PreloadTest.Comment, foreign_key: :post_id
+      timestamps()
+    end
+  end
+
+  defmodule Comment do
+    use Ecto.Schema
+
+    schema "preload_comments" do
+      field :body, :string
+      belongs_to :post, Ectomancer.PreloadTest.Post
+      timestamps()
+    end
+  end
+
+  setup do
+    Application.put_env(:ectomancer, :repo, TestRepo)
+    Ectomancer.DataCase.create_table_for_schema!(Post)
+    Ectomancer.DataCase.create_table_for_schema!(Comment)
+
+    Ectomancer.DataCase.insert!(Post, %{title: "Post 1", body: "Hello", views: 10})
+    Ectomancer.DataCase.insert!(Post, %{title: "Post 2", body: "World", views: 20})
+
+    Ectomancer.DataCase.insert!(Comment, %{body: "Comment 1", post_id: 1})
+    Ectomancer.DataCase.insert!(Comment, %{body: "Comment 2", post_id: 1})
+
+    on_exit(fn ->
+      Application.delete_env(:ectomancer, :repo)
+    end)
+
+    :ok
+  end
+
+  describe "Repo.get with preload" do
+    test "preloads has_many association" do
+      {:ok, post} = Repo.get(Post, %{"id" => 1}, preload: [:comments])
+      assert length(post.comments) == 2
+    end
+
+    test "get without preload returns NotLoaded" do
+      {:ok, post} = Repo.get(Post, %{"id" => 1})
+      assert match?(%Ecto.Association.NotLoaded{}, post.comments)
+    end
+  end
+
+  describe "Repo.list with preload" do
+    test "preloads on all records" do
+      {:ok, posts} = Repo.list(Post, %{}, preload: [:comments])
+      assert length(posts) == 2
+    end
+
+    test "list without preload" do
+      {:ok, posts} = Repo.list(Post, %{})
+      assert Enum.all?(posts, &match?(%Ecto.Association.NotLoaded{}, &1.comments))
+    end
+
+    test "works with filters" do
+      {:ok, posts} = Repo.list(Post, %{"views_gt" => 10}, preload: [:comments])
+      assert length(posts) == 1
+      assert hd(posts).title == "Post 2"
+    end
+  end
+
+  describe "expose macro generates tools with preload" do
+    test "list tool module is generated" do
+      defmodule PreloadTestMCP do
+        use Ectomancer
+
+        expose Ectomancer.PreloadTest.Post,
+          actions: [:list, :get],
+          preload: [:comments]
+      end
+
+      assert {:module, _} = Code.ensure_loaded(PreloadTestMCP.Tool.ListPosts)
+      assert {:module, _} = Code.ensure_loaded(PreloadTestMCP.Tool.GetPost)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `:preload` option to `expose/2` allowing eager-loading of Ecto associations on `list` and `get` operations.

## Changes

- **lib/ectomancer/repo.ex**: `get/2` → `get/3` with opts; `maybe_preload/3` helper applied to both list and get results
- **lib/ectomancer/expose.ex**: `:preload` option in config; conditional handler generation for list/get actions
- **test/ectomancer/preload_test.exs**: 6 integration tests with real SQLite + has_many associations

## Usage

```elixir
expose MyApp.Accounts.User,
  preload: [:posts, :profile]

expose MyApp.Blog.Post,
  preload: [author: :profile, comments: :replies]
```

## Validation

- ✅ 345 tests, 0 failures (was 339)
- ✅ Validated in secondary Phoenix app with User → Post → Comment schemas
- ✅ Nested preload (posts: :comments) works
- ✅ Preload + filters work together
- ✅ Backward compatible — no preload = NotLoaded as before

## Test Plan

`mix test`, `mix credo --strict`, `mix compile --warnings-as-errors` — all clean.

Closes #60