### PR TITLE
Bloco 2: Soft-delete + MCP Resources (closes #59, #63)

### DIFF
--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -102,12 +102,58 @@ defmodule Ectomancer do
       use Anubis.Server,
         name: Keyword.get(unquote(opts), :name, "ectomancer-server"),
         version: Keyword.get(unquote(opts), :version, "0.1.0"),
-        capabilities: [:tools]
+        capabilities: [:tools, :resources]
+
+      Module.register_attribute(__MODULE__, :ectomancer_resources, accumulate: true)
+
+      @before_compile Ectomancer
 
       import Ectomancer.Tool, only: [tool: 2, authorize: 1]
       import Ectomancer.Expose, only: [expose: 1, expose: 2]
       import Ectomancer.RouteIntrospection, only: [expose_routes: 1, expose_routes: 2]
       import Ectomancer.ObanBridge, only: [expose_oban_jobs: 0, expose_oban_jobs: 1]
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    resources = Module.get_attribute(env.module, :ectomancer_resources)
+
+    if resources == [] do
+      quote do
+        :ok
+      end
+    else
+      # The resources attribute accumulates entries in reverse order (LIFO)
+      resources = Enum.reverse(resources)
+
+      quote do
+        defmodule Resource.Schemas do
+          use Anubis.Server.Component,
+            type: :resource,
+            uri: "ectomancer://schemas",
+            name: "schemas",
+            mime_type: "application/json"
+
+          @moduledoc "Available Schemas"
+
+          def description, do: "Lists all available schemas in this Ectomancer server"
+
+          def read(_params, frame) do
+            schemas_list = unquote(Macro.escape(resources))
+
+            {:reply,
+             %Anubis.Server.Response{
+               type: :resource,
+               content: [
+                 %{"type" => "text", "text" => Jason.encode!(%{"schemas" => schemas_list})}
+               ]
+             }, frame}
+          end
+        end
+
+        Anubis.Server.component(Resource.Schemas)
+      end
     end
   end
 end

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -124,7 +124,12 @@ if Code.ensure_loaded?(Ecto) do
         suffix: "",
         description_template: "Update an existing %{resource}"
       },
-      destroy: %{prefix: "destroy", suffix: "", description_template: "Delete a %{resource}"}
+      destroy: %{prefix: "destroy", suffix: "", description_template: "Delete a %{resource}"},
+      restore: %{
+        prefix: "restore",
+        suffix: "",
+        description_template: "Restore a soft-deleted %{resource}"
+      }
     }
 
     @doc """
@@ -141,6 +146,7 @@ if Code.ensure_loaded?(Ecto) do
         * `:readonly` - Disable mutation operations (`:create`, `:update`, `:destroy`)
         * `:namespace` - Prefix tools with namespace
         * `:as` - Alternative resource name
+        * `:soft_delete` - Enable soft-delete awareness (auto-detects `:deleted_at`/`:archived_at` fields)
 
      ## Examples
 
@@ -196,6 +202,10 @@ if Code.ensure_loaded?(Ecto) do
 
       base_actions = Keyword.get(opts, :actions, [:list, :get, :create, :update, :destroy])
       actions = filter_actions_for_readonly(base_actions, readonly)
+      soft_delete = resolve_soft_delete(schema, opts)
+
+      # Auto-add restore for soft-delete enabled schemas
+      actions = if soft_delete, do: actions ++ [:restore], else: actions
 
       exposed_fields = filter_fields(introspection, opts)
       filterable_fields = filter_filterable_fields(exposed_fields, opts)
@@ -211,8 +221,18 @@ if Code.ensure_loaded?(Ecto) do
         introspection: introspection,
         authorization: auth_config,
         readonly: readonly,
-        preload: Keyword.get(opts, :preload, [])
+        preload: Keyword.get(opts, :preload, []),
+        soft_delete: soft_delete
       }
+    end
+
+    defp resolve_soft_delete(schema, opts) do
+      case Keyword.get(opts, :soft_delete) do
+        nil -> false
+        false -> false
+        true -> SchemaIntrospection.soft_delete_field(schema)
+        field when is_atom(field) -> field
+      end
     end
 
     defp filter_actions_for_readonly(actions, true) do
@@ -467,11 +487,21 @@ if Code.ensure_loaded?(Ecto) do
         build_list_filter_params(config.filterable_fields, config.introspection.types)
 
       meta_params =
-        quote do
-          param(:order_by, :string)
-          param(:order_dir, :string)
-          param(:limit, :integer)
-          param(:offset, :integer)
+        if config.soft_delete do
+          quote do
+            param(:order_by, :string)
+            param(:order_dir, :string)
+            param(:limit, :integer)
+            param(:offset, :integer)
+            param(:include_deleted, :boolean)
+          end
+        else
+          quote do
+            param(:order_by, :string)
+            param(:order_dir, :string)
+            param(:limit, :integer)
+            param(:offset, :integer)
+          end
         end
 
       all_params = base_params ++ suffix_params
@@ -490,8 +520,15 @@ if Code.ensure_loaded?(Ecto) do
       pk_field = hd(config.introspection.primary_key)
       pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
-      quote do
-        param(unquote(pk_field), unquote(pk_type), required: true)
+      if config.soft_delete do
+        quote do
+          param(unquote(pk_field), unquote(pk_type), required: true)
+          param(:include_deleted, :boolean)
+        end
+      else
+        quote do
+          param(unquote(pk_field), unquote(pk_type), required: true)
+        end
       end
     end
 
@@ -515,6 +552,16 @@ if Code.ensure_loaded?(Ecto) do
 
     defp generate_params(:destroy, config) do
       # Destroy action requires the primary key
+      pk_field = hd(config.introspection.primary_key)
+      pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      quote do
+        param(unquote(pk_field), unquote(pk_type), required: true)
+      end
+    end
+
+    defp generate_params(:restore, config) do
+      # Restore action requires the primary key
       pk_field = hd(config.introspection.primary_key)
       pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -188,8 +188,19 @@ if Code.ensure_loaded?(Ecto) do
           generate_tool(action, config, tool_name)
         end)
 
+      # Generate MCP Resource module for schema discovery
+      resource_prefix =
+        if config.namespace,
+          do: "#{config.namespace}_#{config.resource_name}",
+          else: config.resource_name
+
+      resource_module_name =
+        Module.concat(__CALLER__.module, "Resource.#{Macro.camelize(resource_prefix)}")
+
+      resource_definition = generate_resource(config, resource_module_name, resource_prefix)
+
       quote do
-        (unquote_splicing(tool_definitions))
+        (unquote_splicing(tool_definitions ++ [resource_definition]))
       end
     end
 
@@ -364,6 +375,84 @@ if Code.ensure_loaded?(Ecto) do
 
         Generated tool: #{inspect(tool_module)}
         """)
+      end
+    end
+
+    # Resource generation for MCP schema discovery
+
+    defp generate_resource(config, module_name, uri_key) do
+      resource_name = config.resource_name
+      schema = config.schema
+      introspection = config.introspection
+      actions = config.actions
+
+      # Build metadata structures at compile time
+      fields_meta =
+        Enum.map(config.exposed_fields, fn field ->
+          ecto_type = Map.get(introspection.types, field)
+
+          %{
+            "name" => Atom.to_string(field),
+            "type" => SchemaIntrospection.type_to_string(ecto_type),
+            "required" =>
+              field not in config.writable_fields and field not in introspection.primary_key
+          }
+        end)
+
+      assocs_meta =
+        Enum.map(introspection.associations, fn assoc ->
+          %{
+            "name" => Atom.to_string(assoc.field),
+            "type" => Atom.to_string(assoc.cardinality),
+            "related" => inspect(assoc.related)
+          }
+        end)
+
+      pk_meta = Enum.map(introspection.primary_key, &Atom.to_string/1)
+      actions_meta = Enum.map(actions, &Atom.to_string/1)
+      schema_module_str = inspect(schema)
+      resource_uri = "ectomancer://schemas/#{uri_key}"
+
+      resource_entry = %{
+        "name" => resource_name,
+        "uri" => resource_uri,
+        "title" => "#{Macro.camelize(resource_name)} Schema"
+      }
+
+      quote do
+        defmodule unquote(module_name) do
+          use Anubis.Server.Component,
+            type: :resource,
+            uri: unquote(resource_uri),
+            name: unquote(resource_name),
+            mime_type: "application/json"
+
+          @moduledoc "Schema metadata for #{unquote(resource_name)}"
+
+          def description, do: "Schema metadata for #{unquote(resource_name)}"
+
+          def read(_params, frame) do
+            metadata = %{
+              "name" => unquote(resource_name),
+              "module" => unquote(schema_module_str),
+              "uri" => unquote(resource_uri),
+              "fields" => unquote(Macro.escape(fields_meta)),
+              "associations" => unquote(Macro.escape(assocs_meta)),
+              "primary_key" => unquote(Macro.escape(pk_meta)),
+              "available_actions" => unquote(Macro.escape(actions_meta))
+            }
+
+            {:reply,
+             %Anubis.Server.Response{
+               type: :resource,
+               content: [%{"type" => "text", "text" => Jason.encode!(metadata)}]
+             }, frame}
+          end
+        end
+
+        require Anubis.Server
+        Anubis.Server.component(unquote(module_name))
+        @ectomancer_resources unquote(Macro.escape(resource_entry))
       end
     end
 

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -69,6 +69,7 @@ if Code.ensure_loaded?(Ecto) do
         query =
           schema_module
           |> build_filter_query(filter_params, introspection.fields)
+          |> apply_soft_delete_filter(schema_module, meta_params)
           |> apply_ordering(meta_params, introspection.fields)
           |> apply_pagination(meta_params, opts)
 
@@ -98,8 +99,17 @@ if Code.ensure_loaded?(Ecto) do
         result = fetch_single_record(repo, schema_module, pk_values)
 
         case result do
-          {:ok, record} -> {:ok, maybe_preload(repo, record, opts)}
-          error -> error
+          {:ok, record} ->
+            sd_field = SchemaIntrospection.soft_delete_field(schema_module)
+
+            if sd_field && Map.get(record, sd_field) && !Map.get(params, "include_deleted", false) do
+              {:error, :not_found}
+            else
+              {:ok, maybe_preload(repo, record, opts)}
+            end
+
+          error ->
+            error
         end
       end
     rescue
@@ -180,10 +190,39 @@ if Code.ensure_loaded?(Ecto) do
       with {:ok, repo} <- get_repo(),
            {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),
            {:ok, record} <- fetch_single_record(repo, schema_module, pk_values) do
-        perform_destroy(repo, record)
+        perform_destroy(repo, schema_module, record)
       end
     rescue
       e -> {:error, "DESTROY failed: #{Exception.message(e)}"}
+    end
+
+    @doc """
+    Restores a soft-deleted record by setting its soft-delete field to `nil`.
+
+    ## Parameters
+
+      * `schema_module` - The Ecto schema module
+      * `params` - Map containing the primary key value
+
+    ## Examples
+
+        restore(MyApp.Accounts.User, %{\"id\" => 123})
+    """
+    @spec restore(module(), map()) :: {:ok, struct()} | {:error, :not_found | :not_soft_deletable | any()}
+    def restore(schema_module, params) do
+      with {:ok, repo} <- get_repo(),
+           {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),
+           {:ok, record} <- fetch_single_record(repo, schema_module, pk_values) do
+        sd_field = SchemaIntrospection.soft_delete_field(schema_module)
+
+        if sd_field do
+          perform_restore(repo, record, sd_field)
+        else
+          {:error, :not_soft_deletable}
+        end
+      end
+    rescue
+      e -> {:error, "RESTORE failed: #{Exception.message(e)}"}
     end
 
     # Private functions
@@ -275,8 +314,37 @@ if Code.ensure_loaded?(Ecto) do
       repo.update(changeset)
     end
 
-    defp perform_destroy(repo, record) do
-      repo.delete(record)
+    defp perform_destroy(repo, schema_module, record) do
+      sd_field = SchemaIntrospection.soft_delete_field(schema_module)
+
+      if sd_field do
+        perform_soft_delete(repo, record, sd_field)
+      else
+        repo.delete(record)
+      end
+    end
+
+    defp perform_soft_delete(repo, record, sd_field) do
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      changeset = Ecto.Changeset.change(record, %{sd_field => now})
+      repo.update(changeset)
+    end
+
+    defp perform_restore(repo, record, sd_field) do
+      changeset = Ecto.Changeset.change(record, %{sd_field => nil})
+      repo.update(changeset)
+    end
+
+    defp apply_soft_delete_filter(query, schema_module, meta_params) do
+      import Ecto.Query
+
+      sd_field = SchemaIntrospection.soft_delete_field(schema_module)
+
+      if sd_field && !Map.get(meta_params, "include_deleted", false) do
+        where(query, [r], is_nil(field(r, ^sd_field)))
+      else
+        query
+      end
     end
 
     defp normalize_params(params, schema_module) do
@@ -324,7 +392,7 @@ if Code.ensure_loaded?(Ecto) do
       end)
     end
 
-    @meta_keys ~w(order_by order_dir limit offset)
+    @meta_keys ~w(order_by order_dir limit offset include_deleted)
 
     defp extract_meta_params(params) do
       {meta, filters} =

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -208,7 +208,8 @@ if Code.ensure_loaded?(Ecto) do
 
         restore(MyApp.Accounts.User, %{\"id\" => 123})
     """
-    @spec restore(module(), map()) :: {:ok, struct()} | {:error, :not_found | :not_soft_deletable | any()}
+    @spec restore(module(), map()) ::
+            {:ok, struct()} | {:error, :not_found | :not_soft_deletable | any()}
     def restore(schema_module, params) do
       with {:ok, repo} <- get_repo(),
            {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),

--- a/lib/ectomancer/schema_introspection.ex
+++ b/lib/ectomancer/schema_introspection.ex
@@ -219,6 +219,35 @@ if Code.ensure_loaded?(Ecto) do
       end)
     end
 
+    @soft_delete_fields [:deleted_at, :archived_at]
+
+    @datetime_types [:utc_datetime, :naive_datetime, :utc_datetime_usec, :naive_datetime_usec]
+
+    @doc """
+    Detects if a schema has a soft-delete field (e.g., `deleted_at`, `archived_at`).
+
+    Returns the field name (atom) if found, `nil` otherwise. Only datetime-type
+    fields are considered valid soft-delete markers.
+
+    ## Examples
+
+        iex> Ectomancer.SchemaIntrospection.soft_delete_field(MyApp.Accounts.User)
+        :deleted_at
+
+        iex> Ectomancer.SchemaIntrospection.soft_delete_field(MyApp.Blog.Post)
+        nil
+    """
+    @spec soft_delete_field(module()) :: atom() | nil
+    def soft_delete_field(schema_module) do
+      Enum.find_value(@soft_delete_fields, fn field ->
+        type = schema_module.__schema__(:type, field)
+
+        if type in @datetime_types do
+          field
+        end
+      end)
+    end
+
     @doc """
     Converts an Ecto type to a human-readable string representation.
 
@@ -275,6 +304,7 @@ else
     def field_info(_schema_module, _field), do: %{type: nil, nullable: true}
     def primary_key(_schema_module), do: []
     def writable_fields(_schema_module), do: []
+    def soft_delete_field(_schema_module), do: nil
     def type_to_string(_type), do: "unknown"
   end
 end

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -371,6 +371,10 @@ if Code.ensure_loaded?(Ecto) do
       {-32_002, "Resource not found", %{}}
     end
 
+    def format_error(:not_soft_deletable) do
+      {-32_602, "Invalid params: Schema does not support soft-delete", %{}}
+    end
+
     def format_error(%Ecto.Changeset{} = changeset) do
       errors = map_changeset_errors(changeset)
       validation_type = infer_validation_type(errors)

--- a/test/ectomancer/soft_delete_test.exs
+++ b/test/ectomancer/soft_delete_test.exs
@@ -1,0 +1,254 @@
+defmodule Ectomancer.SoftDeleteTest do
+  use Ectomancer.DataCase,
+    schemas: [
+      Ectomancer.SoftDeleteTest.Post,
+      Ectomancer.SoftDeleteTest.NoSoftDeletePost
+    ]
+
+  alias Ectomancer.Repo
+  alias Ectomancer.TestRepo
+
+  defmodule Post do
+    use Ecto.Schema
+
+    schema "soft_delete_posts" do
+      field(:title, :string)
+      field(:body, :string)
+      field(:deleted_at, :naive_datetime)
+      timestamps()
+    end
+  end
+
+  defmodule NoSoftDeletePost do
+    use Ecto.Schema
+
+    schema "no_soft_delete_posts" do
+      field(:title, :string)
+      field(:body, :string)
+      timestamps()
+    end
+  end
+
+  setup do
+    Application.put_env(:ectomancer, :repo, TestRepo)
+    Ectomancer.DataCase.create_table_for_schema!(Post)
+    Ectomancer.DataCase.create_table_for_schema!(NoSoftDeletePost)
+
+    Ectomancer.DataCase.insert!(Post, %{title: "Active Post", body: "Hello"})
+    Ectomancer.DataCase.insert!(Post, %{
+      title: "Deleted Post",
+      body: "World",
+      deleted_at: ~N[2024-01-01 00:00:00]
+    })
+
+    Ectomancer.DataCase.insert!(NoSoftDeletePost, %{title: "Normal Post", body: "Yep"})
+
+    on_exit(fn ->
+      Application.delete_env(:ectomancer, :repo)
+    end)
+
+    :ok
+  end
+
+  describe "SchemaIntrospection.soft_delete_field/1" do
+    test "detects deleted_at field" do
+      assert Ectomancer.SchemaIntrospection.soft_delete_field(Post) == :deleted_at
+    end
+
+    test "returns nil for schema without soft-delete field" do
+      assert Ectomancer.SchemaIntrospection.soft_delete_field(NoSoftDeletePost) == nil
+    end
+  end
+
+  describe "Repo.list with soft-delete" do
+    test "filters out soft-deleted records by default" do
+      {:ok, posts} = Repo.list(Post, %{})
+      assert length(posts) == 1
+      assert hd(posts).title == "Active Post"
+    end
+
+    test "includes soft-deleted records when include_deleted: true" do
+      {:ok, posts} = Repo.list(Post, %{"include_deleted" => true})
+      assert length(posts) == 2
+    end
+
+    test "works combined with filters" do
+      {:ok, posts} = Repo.list(Post, %{"title" => "Deleted"})
+      assert length(posts) == 0
+    end
+
+    test "filters with include_deleted combined" do
+      {:ok, posts} = Repo.list(Post, %{"title" => "Deleted Post", "include_deleted" => true})
+      assert length(posts) == 1
+    end
+
+    test "does not affect schemas without soft-delete" do
+      {:ok, posts} = Repo.list(NoSoftDeletePost, %{})
+      assert length(posts) == 1
+    end
+  end
+
+  describe "Repo.get with soft-delete" do
+    test "returns active record normally" do
+      {:ok, post} = Repo.get(Post, %{"id" => 1})
+      assert post.title == "Active Post"
+    end
+
+    test "returns not_found for soft-deleted record" do
+      assert Repo.get(Post, %{"id" => 2}) == {:error, :not_found}
+    end
+
+    test "returns soft-deleted record when include_deleted: true" do
+      {:ok, post} = Repo.get(Post, %{"id" => 2, "include_deleted" => true})
+      assert post.title == "Deleted Post"
+    end
+
+    test "does not affect schemas without soft-delete" do
+      {:ok, post} = Repo.get(NoSoftDeletePost, %{"id" => 1})
+      assert post.title == "Normal Post"
+    end
+  end
+
+  describe "Repo.destroy with soft-delete" do
+    test "soft-deletes record instead of hard delete" do
+      assert {:ok, _deleted_post} = Repo.destroy(Post, %{"id" => 1})
+
+      # Both records are now soft-deleted — list returns none
+      {:ok, posts} = Repo.list(Post, %{})
+      assert length(posts) == 0
+    end
+
+    test "still hard-deletes schemas without soft-delete" do
+      assert {:ok, _} = Repo.destroy(NoSoftDeletePost, %{"id" => 1})
+
+      {:ok, posts} = Repo.list(NoSoftDeletePost, %{})
+      assert length(posts) == 0
+    end
+  end
+
+  describe "Repo.restore" do
+    test "restores a soft-deleted record" do
+      # Update the record to be soft-deleted directly
+      {:ok, record} = Repo.get(Post, %{"id" => 2, "include_deleted" => true})
+      sd_field = Ectomancer.SchemaIntrospection.soft_delete_field(Post)
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      changeset = Ecto.Changeset.change(record, %{sd_field => now})
+      TestRepo.update!(changeset)
+
+      # Verify it's filtered from list
+      {:ok, posts} = Repo.list(Post, %{})
+      assert length(posts) == 1
+
+      # Restore
+      assert {:ok, restored} = Repo.restore(Post, %{"id" => 2})
+      assert restored.deleted_at == nil
+
+      # Now it's back
+      {:ok, posts} = Repo.list(Post, %{})
+      assert length(posts) == 2
+    end
+
+    test "returns not_found for non-existent record" do
+      assert Repo.restore(Post, %{"id" => 999}) == {:error, :not_found}
+    end
+
+    test "returns not_soft_deletable for schema without soft-delete" do
+      assert Repo.restore(NoSoftDeletePost, %{"id" => 1}) == {:error, :not_soft_deletable}
+    end
+  end
+
+  describe "expose macro generates tools with soft_delete" do
+    test "list tool includes include_deleted param" do
+      defmodule SoftDeleteTestMCP do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.Post,
+          actions: [:list, :get, :destroy],
+          soft_delete: true
+        )
+      end
+
+      assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.ListPosts)
+      assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.GetPost)
+      assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.DestroyPost)
+    end
+
+    test "generates restore tool" do
+      defmodule SoftDeleteRestoreTestMCP do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.Post,
+          actions: [:list, :get, :destroy],
+          soft_delete: true
+        )
+      end
+
+      assert {:module, _} = Code.ensure_loaded(SoftDeleteRestoreTestMCP.Tool.RestorePost)
+    end
+
+    test "does not generate restore without soft_delete" do
+      defmodule NoSoftDeleteRestoreMCP do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.NoSoftDeletePost, actions: [:list, :get])
+      end
+
+      refute Code.ensure_loaded?(NoSoftDeleteRestoreMCP.Tool.RestoreNoSoftDeletePost)
+    end
+
+    test "restore tool has correct input params" do
+      defmodule RestoreToolSchema do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.Post,
+          actions: [:list, :get, :destroy],
+          soft_delete: true
+        )
+      end
+
+      schema = RestoreToolSchema.Tool.RestorePost.input_schema()
+      assert schema["type"] == "object"
+      assert schema["properties"]["id"]["type"] == "integer"
+      assert "id" in schema["required"]
+    end
+
+    test "list tool includes include_deleted in schema when soft_delete enabled" do
+      defmodule ListWithSoftDeleteMCP do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.Post,
+          actions: [:list],
+          soft_delete: true
+        )
+      end
+
+      schema = ListWithSoftDeleteMCP.Tool.ListPosts.input_schema()
+      assert schema["properties"]["include_deleted"]["type"] == "boolean"
+    end
+
+    test "get tool includes include_deleted in schema when soft_delete enabled" do
+      defmodule GetWithSoftDeleteMCP do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.Post,
+          actions: [:get],
+          soft_delete: true
+        )
+      end
+
+      schema = GetWithSoftDeleteMCP.Tool.GetPost.input_schema()
+      assert schema["properties"]["include_deleted"]["type"] == "boolean"
+    end
+
+    test "list tool does not include include_deleted when soft_delete not enabled" do
+      defmodule ListWithoutSoftDeleteMCP do
+        use Ectomancer
+
+        expose(Ectomancer.SoftDeleteTest.NoSoftDeletePost, actions: [:list])
+      end
+
+      schema = ListWithoutSoftDeleteMCP.Tool.ListNoSoftDeletePosts.input_schema()
+      refute Map.has_key?(schema["properties"], "include_deleted")
+    end
+  end
+end

--- a/test/ectomancer/soft_delete_test.exs
+++ b/test/ectomancer/soft_delete_test.exs
@@ -35,6 +35,7 @@ defmodule Ectomancer.SoftDeleteTest do
     Ectomancer.DataCase.create_table_for_schema!(NoSoftDeletePost)
 
     Ectomancer.DataCase.insert!(Post, %{title: "Active Post", body: "Hello"})
+
     Ectomancer.DataCase.insert!(Post, %{
       title: "Deleted Post",
       body: "World",
@@ -157,96 +158,79 @@ defmodule Ectomancer.SoftDeleteTest do
     end
   end
 
+  # Test MCP modules for expose macro tests — defined at top level to avoid compiler warnings
+  defmodule SoftDeleteTestMCP do
+    use Ectomancer
+
+    expose(Ectomancer.SoftDeleteTest.Post,
+      actions: [:list, :get, :destroy],
+      soft_delete: true
+    )
+  end
+
+  defmodule NoSoftDeleteRestoreMCP do
+    use Ectomancer
+
+    expose(Ectomancer.SoftDeleteTest.NoSoftDeletePost, actions: [:list, :get])
+  end
+
+  defmodule ListWithSoftDeleteMCP do
+    use Ectomancer
+
+    expose(Ectomancer.SoftDeleteTest.Post,
+      actions: [:list],
+      soft_delete: true
+    )
+  end
+
+  defmodule GetWithSoftDeleteMCP do
+    use Ectomancer
+
+    expose(Ectomancer.SoftDeleteTest.Post,
+      actions: [:get],
+      soft_delete: true
+    )
+  end
+
+  defmodule ListWithoutSoftDeleteMCP do
+    use Ectomancer
+
+    expose(Ectomancer.SoftDeleteTest.NoSoftDeletePost, actions: [:list])
+  end
+
   describe "expose macro generates tools with soft_delete" do
     test "list tool includes include_deleted param" do
-      defmodule SoftDeleteTestMCP do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.Post,
-          actions: [:list, :get, :destroy],
-          soft_delete: true
-        )
-      end
-
       assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.ListPosts)
       assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.GetPost)
       assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.DestroyPost)
     end
 
     test "generates restore tool" do
-      defmodule SoftDeleteRestoreTestMCP do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.Post,
-          actions: [:list, :get, :destroy],
-          soft_delete: true
-        )
-      end
-
-      assert {:module, _} = Code.ensure_loaded(SoftDeleteRestoreTestMCP.Tool.RestorePost)
+      assert {:module, _} = Code.ensure_loaded(SoftDeleteTestMCP.Tool.RestorePost)
     end
 
     test "does not generate restore without soft_delete" do
-      defmodule NoSoftDeleteRestoreMCP do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.NoSoftDeletePost, actions: [:list, :get])
-      end
-
       refute Code.ensure_loaded?(NoSoftDeleteRestoreMCP.Tool.RestoreNoSoftDeletePost)
     end
 
     test "restore tool has correct input params" do
-      defmodule RestoreToolSchema do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.Post,
-          actions: [:list, :get, :destroy],
-          soft_delete: true
-        )
-      end
-
-      schema = RestoreToolSchema.Tool.RestorePost.input_schema()
+      schema = SoftDeleteTestMCP.Tool.RestorePost.input_schema()
       assert schema["type"] == "object"
       assert schema["properties"]["id"]["type"] == "integer"
       assert "id" in schema["required"]
     end
 
     test "list tool includes include_deleted in schema when soft_delete enabled" do
-      defmodule ListWithSoftDeleteMCP do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.Post,
-          actions: [:list],
-          soft_delete: true
-        )
-      end
-
       schema = ListWithSoftDeleteMCP.Tool.ListPosts.input_schema()
       assert schema["properties"]["include_deleted"]["type"] == "boolean"
     end
 
     test "get tool includes include_deleted in schema when soft_delete enabled" do
-      defmodule GetWithSoftDeleteMCP do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.Post,
-          actions: [:get],
-          soft_delete: true
-        )
-      end
-
       schema = GetWithSoftDeleteMCP.Tool.GetPost.input_schema()
       assert schema["properties"]["include_deleted"]["type"] == "boolean"
     end
 
     test "list tool does not include include_deleted when soft_delete not enabled" do
-      defmodule ListWithoutSoftDeleteMCP do
-        use Ectomancer
-
-        expose(Ectomancer.SoftDeleteTest.NoSoftDeletePost, actions: [:list])
-      end
-
       schema = ListWithoutSoftDeleteMCP.Tool.ListNoSoftDeletePosts.input_schema()
       refute Map.has_key?(schema["properties"], "include_deleted")
     end


### PR DESCRIPTION
## Bloco 2 completo 🎉

### ✅ Soft-delete Awareness (#63)

Adds first-class soft-delete support. When a schema has a `deleted_at` or `archived_at` datetime field, Ectomancer automatically:
- **Filters out soft-deleted records** from `list` and `get` by default
- **Maps `destroy` to soft-delete** (set `deleted_at` instead of hard delete)
- **Exposes `include_deleted` param** on list/get tools for admin use
- **Exposes a `restore` action** for schemas with soft-delete enabled

Usage:
```elixir
expose MyApp.Accounts.User, soft_delete: true
# Gera: list_users, get_user, destroy_user (soft), restore_user
#        + include_deleted param em list/get
```

Files: `schema_introspection.ex`, `repo.ex`, `expose.ex`, `tool.ex`, `soft_delete_test.exs`
23 new tests.

---

### ✅ MCP Resources (#59)

Each `expose`d schema now also registers as an **MCP Resource** for data model discovery:

```
ectomancer://schemas           → lists all available schemas
ectomancer://schemas/users     → schema metadata: fields, types, associations, actions
```

Resources return JSON metadata including field names, Ecto types, associations, primary keys, and available CRUD actions — letting LLMs discover the data model before calling tools.

Implementation:
- `capabilities: [:tools, :resources]` in Anubis.Server
- Per-schema Resource module generated at compile time via `use Anubis.Server.Component, type: :resource`
- Root `ectomancer://schemas` resource generated via `@before_compile`
- Resource URIs respect `:namespace` and `:as` options to avoid collisions

Files: `ectomancer.ex`, `expose.ex`
0 new warnings in --warnings-as-errors mode.