### PR TITLE
feat: field-level dynamic authorization (closes #62)

### DIFF
--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -147,6 +147,7 @@ if Code.ensure_loaded?(Ecto) do
         * `:namespace` - Prefix tools with namespace
         * `:as` - Alternative resource name
         * `:soft_delete` - Enable soft-delete awareness (auto-detects `:deleted_at`/`:archived_at` fields)
+        * `:field_authorize` - Dynamic field-level authorization callback `fn actor, field -> boolean :: boolean()`
 
      ## Examples
 
@@ -233,7 +234,8 @@ if Code.ensure_loaded?(Ecto) do
         authorization: auth_config,
         readonly: readonly,
         preload: Keyword.get(opts, :preload, []),
-        soft_delete: soft_delete
+        soft_delete: soft_delete,
+        field_authorize: Keyword.get(opts, :field_authorize)
       }
     end
 
@@ -465,7 +467,7 @@ if Code.ensure_loaded?(Ecto) do
       params = generate_params(action, config)
       auth_block = generate_authorization_block(action, config)
 
-      handler =
+      base_handler =
         if action in [:list, :get] and config.preload != [] do
           quote do
             fn params, _actor, scope ->
@@ -481,6 +483,28 @@ if Code.ensure_loaded?(Ecto) do
               Ectomancer.Repo.unquote(action)(unquote(config.schema), params, scope: scope)
             end
           end
+        end
+
+      handler =
+        if config.field_authorize do
+          field_auth_fn = config.field_authorize
+
+          quote do
+            fn params, actor, scope ->
+              inner = unquote(base_handler)
+              result = inner.(params, actor, scope)
+
+              case result do
+                {:ok, data} ->
+                  {:ok, Ectomancer.FieldAuth.filter_fields(data, actor, unquote(field_auth_fn))}
+
+                other ->
+                  other
+              end
+            end
+          end
+        else
+          base_handler
         end
 
       quote do

--- a/lib/ectomancer/field_auth.ex
+++ b/lib/ectomancer/field_auth.ex
@@ -1,0 +1,57 @@
+defmodule Ectomancer.FieldAuth do
+  @moduledoc """
+  Field-level authorization for Ectomancer tools.
+
+  Allows filtering record fields based on actor permissions after a tool
+  executes. Field auth is applied as a response transform — the DB query
+  is unaffected, only the returned data is filtered.
+
+  ## Usage
+
+      expose MyApp.Accounts.User,
+        field_authorize: fn actor, field ->
+          case field do
+            :password_hash -> actor.role == :admin
+            :salary -> actor.role == :admin
+            :email -> true
+            _ -> actor != nil
+          end
+        end
+
+  The callback receives the actor and the field name (as an atom) and
+  should return `true` (allow) or `false` (deny).
+  """
+
+  @doc """
+  Filters fields from a tool result based on an authorization callback.
+
+  Works with single structs, lists of structs, and plain maps.
+
+  ## Examples
+
+      iex> filter_fields(%User{email: "a@b.com", password_hash: "secret"}, %{role: :admin}, fn _, _ -> true end)
+      %{email: "a@b.com", password_hash: "secret"}
+
+      iex> filter_fields(%User{email: "a@b.com", password_hash: "secret"}, %{role: :user}, fn
+      ...>   _actor, :password_hash -> false
+      ...>   _actor, _ -> true
+      ...> end)
+      %{email: "a@b.com"}
+  """
+  @spec filter_fields(any(), any(), function()) :: any()
+  def filter_fields(data, _actor, nil), do: data
+  def filter_fields(data, _actor, auth_fn) when not is_function(auth_fn, 2), do: data
+
+  def filter_fields(data, actor, auth_fn) when is_list(data) do
+    Enum.map(data, &filter_fields(&1, actor, auth_fn))
+  end
+
+  def filter_fields(%{__struct__: _} = record, actor, auth_fn) do
+    record
+    |> Map.from_struct()
+    |> Enum.filter(fn {field, _value} -> auth_fn.(actor, field) end)
+    |> Map.new()
+  end
+
+  def filter_fields(data, _actor, _auth_fn), do: data
+end

--- a/test/ectomancer/field_auth_test.exs
+++ b/test/ectomancer/field_auth_test.exs
@@ -1,0 +1,169 @@
+defmodule Ectomancer.FieldAuthTest do
+  use Ectomancer.DataCase,
+    schemas: [Ectomancer.FieldAuthTest.User]
+
+  alias Ectomancer.TestRepo
+
+  defmodule User do
+    use Ecto.Schema
+
+    schema "field_auth_users" do
+      field(:email, :string)
+      field(:name, :string)
+      field(:password_hash, :string)
+      field(:salary, :integer)
+      timestamps()
+    end
+  end
+
+  defmodule AdminMCP do
+    use Ectomancer, name: "field-auth-admin", version: "1.0.0"
+
+    expose(User,
+      actions: [:list, :get],
+      field_authorize: fn _actor, _field -> true end
+    )
+  end
+
+  defmodule UserMCP do
+    use Ectomancer, name: "field-auth-user", version: "1.0.0"
+
+    expose(User,
+      actions: [:list, :get],
+      field_authorize: fn actor, field ->
+        cond do
+          field in [:password_hash, :salary] -> actor.role == :admin
+          true -> true
+        end
+      end
+    )
+  end
+
+  setup do
+    Application.put_env(:ectomancer, :repo, TestRepo)
+    Ectomancer.DataCase.create_table_for_schema!(User)
+
+    Ectomancer.DataCase.insert!(User, %{
+      email: "admin@test.com",
+      name: "Admin User",
+      password_hash: "admin_secret",
+      salary: 100_000
+    })
+
+    Ectomancer.DataCase.insert!(User, %{
+      email: "user@test.com",
+      name: "Regular User",
+      password_hash: "user_secret",
+      salary: 50_000
+    })
+
+    on_exit(fn ->
+      Application.delete_env(:ectomancer, :repo)
+    end)
+
+    :ok
+  end
+
+  describe "Ectomancer.FieldAuth.filter_fields/3" do
+    test "returns all fields when auth_fn returns true for all" do
+      user = %User{email: "a@b.com", name: "Test", password_hash: "secret", salary: 100}
+      result = Ectomancer.FieldAuth.filter_fields(user, %{}, fn _, _ -> true end)
+      assert result.email == "a@b.com"
+      assert result.password_hash == "secret"
+      assert result.salary == 100
+    end
+
+    test "filters out sensitive fields" do
+      user = %User{email: "a@b.com", name: "Test", password_hash: "secret", salary: 100}
+
+      result =
+        Ectomancer.FieldAuth.filter_fields(user, %{role: :user}, fn actor, field ->
+          if field in [:password_hash, :salary], do: actor.role == :admin, else: true
+        end)
+
+      assert result.email == "a@b.com"
+      assert result.name == "Test"
+      refute Map.has_key?(result, :password_hash)
+      refute Map.has_key?(result, :salary)
+    end
+
+    test "admin sees all fields" do
+      user = %User{email: "a@b.com", name: "Test", password_hash: "secret", salary: 100}
+
+      result =
+        Ectomancer.FieldAuth.filter_fields(user, %{role: :admin}, fn actor, field ->
+          if field in [:password_hash, :salary], do: actor.role == :admin, else: true
+        end)
+
+      assert result.email == "a@b.com"
+      assert result.password_hash == "secret"
+      assert result.salary == 100
+    end
+
+    test "works with lists" do
+      users = [
+        %User{email: "a@b.com", password_hash: "s1", salary: 100},
+        %User{email: "c@d.com", password_hash: "s2", salary: 200}
+      ]
+
+      result =
+        Ectomancer.FieldAuth.filter_fields(users, %{role: :user}, fn actor, field ->
+          if field in [:password_hash, :salary], do: actor.role == :admin, else: true
+        end)
+
+      assert length(result) == 2
+
+      Enum.each(result, fn u ->
+        assert u.email
+        refute Map.has_key?(u, :password_hash)
+        refute Map.has_key?(u, :salary)
+      end)
+    end
+
+    test "nil auth_fn returns data unchanged" do
+      user = %User{email: "a@b.com"}
+      assert Ectomancer.FieldAuth.filter_fields(user, %{}, nil) == user
+    end
+  end
+
+  describe "expose macro with field_authorize" do
+    test "admin MCP generates tools with field_authorize" do
+      assert {:module, _} = Code.ensure_loaded(AdminMCP.Tool.ListUsers)
+      assert {:module, _} = Code.ensure_loaded(AdminMCP.Tool.GetUser)
+    end
+
+    test "user MCP generates tools with field_authorize" do
+      assert {:module, _} = Code.ensure_loaded(UserMCP.Tool.ListUsers)
+      assert {:module, _} = Code.ensure_loaded(UserMCP.Tool.GetUser)
+    end
+  end
+
+  describe "tool execution with field_authorize" do
+    test "admin sees sensitive fields" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin}}}
+      {:reply, response, _frame} = UserMCP.Tool.GetUser.execute(%{"id" => 1}, frame)
+      text = response.content |> List.first() |> Map.get("text")
+      assert text =~ "password_hash"
+      assert text =~ "salary"
+    end
+
+    test "regular user does not see sensitive fields" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :user}}}
+      {:reply, response, _frame} = UserMCP.Tool.GetUser.execute(%{"id" => 1}, frame)
+      text = response.content |> List.first() |> Map.get("text")
+      refute text =~ "password_hash"
+      refute text =~ "salary"
+      assert text =~ "admin@test.com"
+    end
+
+    test "list respects field_authorize" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :user}}}
+      {:reply, response, _frame} = UserMCP.Tool.ListUsers.execute(%{}, frame)
+      text = response.content |> List.first() |> Map.get("text")
+      refute text =~ "password_hash"
+      refute text =~ "salary"
+      assert text =~ "user@test.com"
+      assert text =~ "admin@test.com"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds dynamic field-level authorization — the ability to control which fields each actor can see in tool responses, based on a callback.

## Usage

```elixir
expose MyApp.Accounts.User,
  field_authorize: fn actor, field ->
    case field do
      :password_hash -> actor.role == :admin
      :salary -> actor.role == :admin
      :email -> true
      _ -> actor != nil
    end
  end
```

## Implementation

- **Ectomancer.FieldAuth** module with `filter_fields/3` (single struct, list, maps)
- **expose** accepts `:field_authorize` option — wraps generated handlers
- Field filtering is a response transform after DB query (no query impact)
- Compatible with `:only`/`:except` (applied after those filters) and preloading
- 10 new tests