### PR TITLE
MCP Resources for schema discovery — auto-register schema metadata as MCP resources (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **MCP Resources for schema discovery** — Each `expose`d schema now automatically registers an MCP resource at `ectomancer://schemas/{name}` returning full schema metadata (fields, types, associations, primary key, available actions). A top-level `ectomancer://schemas` resource lists all registered schemas. Opt-out per schema with `resource: false`. (Closes #56)
 - **Rate limiting** — Token bucket algorithm with ETS storage. Configurable per-tool and global limits. Opt-in via `config :ectomancer, :rate_limits`.
 - **Multi-repo support** — expose schemas from different repos with `expose User, repo: MyApp.ReplicaRepo`. Falls back to global repo config.
 - **Browser MCP client** — Zero-dependency HTML browser client at `priv/ectomancer.html`. Browse tools, call them, see results. No build step required.

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -189,19 +189,24 @@ if Code.ensure_loaded?(Ecto) do
           generate_tool(action, config, tool_name)
         end)
 
-      # Generate MCP Resource module for schema discovery
-      resource_prefix =
-        if config.namespace,
-          do: "#{config.namespace}_#{config.resource_name}",
-          else: config.resource_name
+      # Generate MCP Resource module for schema discovery (opt-out with resource: false)
+      resource_definitions =
+        if config.resource do
+          resource_prefix =
+            if config.namespace,
+              do: "#{config.namespace}_#{config.resource_name}",
+              else: config.resource_name
 
-      resource_module_name =
-        Module.concat(__CALLER__.module, "Resource.#{Macro.camelize(resource_prefix)}")
+          resource_module_name =
+            Module.concat(__CALLER__.module, "Resource.#{Macro.camelize(resource_prefix)}")
 
-      resource_definition = generate_resource(config, resource_module_name, resource_prefix)
+          [generate_resource(config, resource_module_name, resource_prefix)]
+        else
+          []
+        end
 
       quote do
-        (unquote_splicing(tool_definitions ++ [resource_definition]))
+        (unquote_splicing(tool_definitions ++ resource_definitions))
       end
     end
 
@@ -236,7 +241,8 @@ if Code.ensure_loaded?(Ecto) do
         preload: Keyword.get(opts, :preload, []),
         soft_delete: soft_delete,
         field_authorize: Keyword.get(opts, :field_authorize),
-        repo: Keyword.get(opts, :repo)
+        repo: Keyword.get(opts, :repo),
+        resource: Keyword.get(opts, :resource, true)
       }
     end
 

--- a/test/ectomancer/resource_test.exs
+++ b/test/ectomancer/resource_test.exs
@@ -1,0 +1,233 @@
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+defmodule Ectomancer.ResourceTest do
+  use ExUnit.Case
+
+  defmodule TestUser do
+    use Ecto.Schema
+
+    schema "test_users" do
+      field(:email, :string)
+      field(:name, :string)
+      field(:age, :integer)
+      timestamps()
+    end
+  end
+
+  defmodule TestPost do
+    use Ecto.Schema
+
+    schema "test_posts" do
+      field(:title, :string)
+      field(:body, :string)
+      belongs_to(:user, Ectomancer.ResourceTest.TestUser)
+      timestamps()
+    end
+  end
+
+  defmodule ResourceMCP do
+    use Ectomancer, name: "resource-test", version: "1.0.0"
+
+    expose(TestUser, actions: [:list, :get, :create])
+    expose(TestPost, actions: [:list, :get])
+  end
+
+  describe "per-schema resource generation" do
+    test "generates Resource module for each schema" do
+      assert {:module, _} = Code.ensure_loaded(ResourceMCP.Resource.TestUser)
+      assert {:module, _} = Code.ensure_loaded(ResourceMCP.Resource.TestPost)
+    end
+
+    test "resource module has correct URI" do
+      assert ResourceMCP.Resource.TestUser.uri() == "ectomancer://schemas/test_user"
+      assert ResourceMCP.Resource.TestPost.uri() == "ectomancer://schemas/test_post"
+    end
+
+    test "resource module has correct name" do
+      assert ResourceMCP.Resource.TestUser.name() == "test_user"
+      assert ResourceMCP.Resource.TestPost.name() == "test_post"
+    end
+
+    test "resource module has description" do
+      assert ResourceMCP.Resource.TestUser.description() == "Schema metadata for test_user"
+      assert ResourceMCP.Resource.TestPost.description() == "Schema metadata for test_post"
+    end
+
+    test "resource read returns JSON with schema metadata" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = ResourceMCP.Resource.TestUser.read(%{}, frame)
+
+      assert response.type == :resource
+      assert [%{"type" => "text", "text" => json}] = response.content
+
+      metadata = Jason.decode!(json)
+
+      assert metadata["name"] == "test_user"
+      assert metadata["module"] == "Ectomancer.ResourceTest.TestUser"
+      assert metadata["uri"] == "ectomancer://schemas/test_user"
+      assert is_list(metadata["fields"])
+      assert is_list(metadata["associations"])
+      assert is_list(metadata["primary_key"])
+      assert is_list(metadata["available_actions"])
+    end
+
+    test "resource fields contain type and required info" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = ResourceMCP.Resource.TestPost.read(%{}, frame)
+
+      assert [%{"text" => json}] = response.content
+      metadata = Jason.decode!(json)
+
+      title_field = Enum.find(metadata["fields"], fn f -> f["name"] == "title" end)
+      assert title_field
+      assert title_field["type"] == "string"
+    end
+
+    test "resource available_actions reflects expose config" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = ResourceMCP.Resource.TestUser.read(%{}, frame)
+      assert [%{"text" => json}] = response.content
+      metadata = Jason.decode!(json)
+
+      # TestUser has list, get, create (not update or destroy)
+      assert "list" in metadata["available_actions"]
+      assert "get" in metadata["available_actions"]
+      assert "create" in metadata["available_actions"]
+      refute "update" in metadata["available_actions"]
+      refute "destroy" in metadata["available_actions"]
+    end
+
+    test "resource associations reflect schema relationships" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = ResourceMCP.Resource.TestPost.read(%{}, frame)
+      assert [%{"text" => json}] = response.content
+      metadata = Jason.decode!(json)
+
+      user_assoc = Enum.find(metadata["associations"], fn a -> a["name"] == "user" end)
+      assert user_assoc
+      assert user_assoc["type"] == "one"
+      assert user_assoc["related"] == "Ectomancer.ResourceTest.TestUser"
+    end
+  end
+
+  describe "top-level schemas resource" do
+    test "generates Resource.Schemas module" do
+      assert {:module, _} = Code.ensure_loaded(ResourceMCP.Resource.Schemas)
+    end
+
+    test "has correct URI" do
+      assert ResourceMCP.Resource.Schemas.uri() == "ectomancer://schemas"
+    end
+
+    test "lists all registered schemas" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = ResourceMCP.Resource.Schemas.read(%{}, frame)
+
+      assert [%{"type" => "text", "text" => json}] = response.content
+      result = Jason.decode!(json)
+
+      assert is_map(result)
+      assert is_list(result["schemas"])
+
+      schema_names = Enum.map(result["schemas"], fn s -> s["name"] end)
+      assert "test_user" in schema_names
+      assert "test_post" in schema_names
+    end
+
+    test "schemas listing includes URI and title" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = ResourceMCP.Resource.Schemas.read(%{}, frame)
+      assert [%{"text" => json}] = response.content
+      result = Jason.decode!(json)
+
+      test_user_entry = Enum.find(result["schemas"], fn s -> s["name"] == "test_user" end)
+      assert test_user_entry
+      assert test_user_entry["uri"] == "ectomancer://schemas/test_user"
+      assert test_user_entry["title"] == "TestUser Schema"
+    end
+  end
+
+  describe "resource opt-out with resource: false" do
+    defmodule OtherSchema do
+      use Ecto.Schema
+
+      schema "other_records" do
+        field(:label, :string)
+        timestamps()
+      end
+    end
+
+    defmodule NoResourceMCP do
+      use Ectomancer, name: "no-resource-test", version: "1.0.0"
+
+      expose(TestUser, resource: false, actions: [:list])
+      expose(OtherSchema, actions: [:list])
+    end
+
+    test "does not generate Resource module for opt-out schemas" do
+      refute Code.ensure_loaded?(NoResourceMCP.Resource.TestUser)
+    end
+
+    test "still generates tools even without resource" do
+      assert Code.ensure_loaded?(NoResourceMCP.Tool.ListTestUsers)
+    end
+
+    test "excluded schema does not appear in top-level schemas" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = NoResourceMCP.Resource.Schemas.read(%{}, frame)
+      assert [%{"text" => json}] = response.content
+      result = Jason.decode!(json)
+
+      schema_names = Enum.map(result["schemas"], fn s -> s["name"] end)
+      refute "test_user" in schema_names
+      assert "other_schema" in schema_names
+    end
+  end
+
+  describe "resource with namespace" do
+    defmodule NamespacedResourceMCP do
+      use Ectomancer, name: "namespace-test", version: "1.0.0"
+
+      expose(TestUser, namespace: :admin, actions: [:list])
+    end
+
+    test "uri includes namespace prefix" do
+      assert NamespacedResourceMCP.Resource.AdminTestUser.uri() ==
+               "ectomancer://schemas/admin_test_user"
+    end
+
+    test "top-level schemas include namespaced resources" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = NamespacedResourceMCP.Resource.Schemas.read(%{}, frame)
+      assert [%{"text" => json}] = response.content
+      result = Jason.decode!(json)
+
+      schema_names = Enum.map(result["schemas"], fn s -> s["name"] end)
+      assert "test_user" in schema_names
+    end
+  end
+
+  describe "resource with custom name via :as" do
+    defmodule AliasedResourceMCP do
+      use Ectomancer, name: "alias-test", version: "1.0.0"
+
+      expose(TestUser, as: :admin_users, actions: [:list])
+    end
+
+    test "uri uses the custom name" do
+      assert AliasedResourceMCP.Resource.AdminUsers.uri() ==
+               "ectomancer://schemas/admin_users"
+    end
+
+    test "resource name is the aliased name" do
+      assert AliasedResourceMCP.Resource.AdminUsers.name() == "admin_users"
+    end
+  end
+end


### PR DESCRIPTION
## What

Expose Ecto schema metadata as MCP Resources so LLMs can discover the data model before calling tools. Each `expose`d schema automatically registers a resource at `ectomancer://schemas/{name}` returning full metadata (fields, types, associations, primary key, available actions). A top-level `ectomancer://schemas` resource lists all registered schemas.

## Changes

- Per-schema MCP resources at `ectomancer://schemas/{name}` with JSON schema metadata
- Top-level `ectomancer://schemas` resource listing all schemas
- `resource: false` opt-out option per schema
- Supports namespace and `:as` naming in resource URIs
- 19 new tests covering: resource module generation, metadata correctness, opt-out, namespaces, aliases, and top-level listing

## Test Plan

- [x] 417 tests, 0 failures
- [x] Compile zero warnings
- [x] Format compliance
- [x] Credo strict — zero issues
- [x] Dialyzer — zero errors
- [x] 19 new resource tests, 398+ total

Closes #56