### PR TITLE
Release v1.2.0: MCP Resources, dynamic preloading, rate limiting, multi-repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-13
+
 ### Added
 - **MCP Resources for schema discovery** — Each `expose`d schema now automatically registers an MCP resource at `ectomancer://schemas/{name}` returning full schema metadata (fields, types, associations, primary key, available actions). A top-level `ectomancer://schemas` resource lists all registered schemas. Opt-out per schema with `resource: false`. (Closes #56)
 - **Dynamic association preloading** — New `preloadable` option for `expose` allows LLMs to dynamically request associated records via an `include` parameter on `list` and `get` tools. Supports `preloadable: true` (all associations) or `preloadable: [:posts, :comments]` (specific). Requested includes are validated against allowed associations. (Closes #57)
@@ -21,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error handling now returns structured `{:error, %{code:, message:, details:}}` tuples consistently.
 
 ### Testing
-- **398 tests** (up from 260), all passing
+- **426 tests** (up from 260), all passing
+- 28 new tests: 19 for MCP Resources, 9 for dynamic preloading
 - 9 new rate limiter tests
 - Validated multi-repo integration with secondary Phoenix app (SQLite)
 
@@ -251,7 +254,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v1.0.0
 [0.1.0-rc.4]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v0.1.0-rc.4

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and p
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 1.1"}
+    {:ectomancer, "~> 1.2"}
   ]
 end
 ```
@@ -455,7 +455,7 @@ This project is in active development.
 - ✅ Read-only mode for schemas
 - ✅ Ecto changeset error mapping to MCP error responses
 
-Current version: 1.1.0
+Current version: 1.2.0
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "1.1.0"
+  @version "1.2.0"
 
   def project do
     [


### PR DESCRIPTION
## What

Release v1.2.0 — a significant feature release with 7 major additions.

## Changes since v1.1.0

### Added
- **MCP Resources for schema discovery** (closes #56) — each `expose`d schema auto-registers an MCP resource at `ectomancer://schemas/{name}` with full metadata. `resource: false` opt-out.
- **Dynamic association preloading** (closes #57) — `preloadable: true | [:posts]` option enables `include` parameter on list/get tools. Validated against allowlist.
- **Rate limiting** — Token bucket with ETS. Per-tool and global limits. `config :ectomancer, :rate_limits`.
- **Multi-repo support** — `expose User, repo: MyApp.ReplicaRepo` for cross-database schemas.
- **Browser MCP client** — Zero-dep HTML client at `priv/ectomancer.html`. No build step.
- **ExDoc auto-deploy** — CI workflow builds docs on push to main.
- **CI, Hex, and Docs badges** on README.

### Fixed
- `singularize` handles edge cases (`status`, `address`, `series`)
- Error handling returns structured `{:error, %{code:, message:, details:}}`

### Testing
- **426 tests** (up from 260), all passing
- 28 new tests for MCP Resources + dynamic preloading

## Pre-release checklist
- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix credo --strict` — 0 issues
- [x] `mix dialyzer --halt-exit-status` — 0 errors
- [x] `mix test` — 426 tests, 0 failures
- [x] Consumer app validation (8/8 tests passing)