### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-05-13
+
+### Fixed
+- **Hex publish compatibility** — Replaced `inflex` (GitHub dep, blocked hex.publish) with
+  `plurality` (Hex dep) for route name singularization. Plurality is a modern, zero-regex
+  inflection library with verified accuracy across 80k+ noun pairs.
+
+### Changed
+- `mix.exs` dependency: `inflex` → `plurality ~> 0.2`
+- `RouteIntrospection.singularize/1` now calls `Plurality.singularize/1` directly
+
 ## [1.2.0] - 2026-05-13
 
 ### Added
@@ -254,7 +265,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/GustavoZiaugra/ectomancer/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ This project is in active development.
 - ✅ Read-only mode for schemas
 - ✅ Ecto changeset error mapping to MCP error responses
 
-Current version: 1.2.0
+Current version: 1.2.1
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "1.2.0"
+  @version "1.2.1"
 
   def project do
     [


### PR DESCRIPTION
## Release v1.2.1 — Hex publish fix

Patch release fixing the `mix hex.publish` build error by replacing the Git-only `inflex` dependency with `plurality` (available on Hex).

### Changes

- **mix.exs**: `@version 1.2.1`, dependency `inflex` → `plurality ~> 0.2`
- **CHANGELOG**: v1.2.1 section with Fixed and Changed entries
- **README**: version bumped from 1.2.0 to 1.2.1

### Verification

- `mix compile --warnings-as-errors` — clean
- `mix test` — 426 tests, 0 failures
- `MIX_ENV=prod mix hex.publish` — package build OK (auth pending)