### PR TITLE
Add demo asciicast and sample app to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and t
 - **Oban integration** — optional bridge for inspecting queue depth and workers
 - **Interactive installer** — `mix ectomancer.setup` auto-discovers schemas and patches your project
 
+## Demo
+
+Watch Ectomancer in action — a full Phoenix app with User, Post, and Comment schemas exposed as MCP tools, running on the Streamable HTTP transport.
+
+[![asciicast](https://asciinema.org/a/DUbHClUUK8kTkff7.svg)](https://asciinema.org/a/DUbHClUUK8kTkff7)
+
+*Click the image above to watch the interactive terminal demo.*
+
+The demo shows:
+- **3 Ecto schemas** → **15 MCP tools** (list, get, create, update, destroy) with zero boilerplate
+- **Advanced filtering** — `list_posts(title_contains: "hello")` with automatic LIKE operators
+- **Association support** — create posts linked to users through MCP tool calls
+- **Real-time interaction** — query, create, and update records conversationally
+
+Try it yourself:
+
+```bash
+git clone https://github.com/GustavoZiaugra/ectomancer_demo
+cd ectomancer_demo
+mix setup
+mix phx.server
+# Connect your MCP client to http://localhost:4000/mcp
+```
+
 ## Installation
 
 ```elixir


### PR DESCRIPTION
Closes #16

## Changes

- Add **Demo** section to README with embedded asciicast
- Created [ectomancer_demo](https://github.com/GustavoZiaugra/ectomancer_demo) — full Phoenix app with User, Post, Comment schemas exposing 15 MCP tools
- Asciicast shows the complete workflow: initialize, tools/list, list_users, create_user, get_user, list_posts with filter, create_post, update_user

## Demo

[![asciicast](https://asciinema.org/a/DUbHClUUK8kTkff7.svg)](https://asciinema.org/a/DUbHClUUK8kTkff7)

Click the badge above to watch the interactive terminal demo.