### PR TITLE
Release v1.3.0: Custom MCP resource macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-19
+
 ### Added
 - `resource/2` macro for defining custom MCP resources, parallel to the existing `tool/2` macro
   - Static resources (`uri "scheme://path"`) and templated resources (`uri "scheme://{var}"`)
@@ -279,7 +281,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ mix test
 
 Zero compiler warnings, full Credo and Dialyzer compliance.
 
-Current version: **1.2.1**
+Current version: **1.3.0**
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "1.2.1"
+  @version "1.3.0"
 
   def project do
     [


### PR DESCRIPTION
## What

Release v1.3.0 — adds a `resource/2` macro for defining custom MCP resources, parallel to the existing `tool/2` macro.

## Changes

- **Version bump:** `1.2.1` → `1.3.0`
- **CHANGELOG:** Unreleased entries moved to `[1.3.0]` section
- **README:** Current version updated

## Changelog

### Added
- `resource/2` macro for defining custom MCP resources, parallel to the existing `tool/2` macro
  - Static resources (`uri scheme://path`) and templated resources (`uri scheme://{var}`)
  - Optional `authorize` block for access control
  - Configurable `mime_type` (defaults to `text/plain`)
  - Read handler `fn params, actor -> {:ok, content} | {:error, reason} end`
- Per-schema metadata resources now auto-generated from `expose` alongside existing tools
- `:resource` option in `expose/2` accepts `false` to opt out of per-schema resource generation
- 19 new tests for custom resource DSL

### Changed
- `use Ectomancer` now imports `resource: 2` macro
- Capabilities updated to include `[:tools, :resources]`

## Test Plan

- [x] 445 tests pass across OTP 26.2, 27.3, 28.1
- [x] `mix format --check-formatted` passes
- [x] `mix credo --strict` passes
- [x] Consumer validation with standalone project

Closes #89