### PR TITLE
Refactor: extract perform_rate_check/4 to reduce nesting depth (fixes #93)

### DIFF
--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -144,19 +144,23 @@ if Code.ensure_loaded?(Ecto) do
 
                 key = if per_actor, do: {:actor, actor}, else: :global
 
-                case Ectomancer.RateLimiter.check(max: max, window_ms: window_ms, key: key) do
-                  :ok ->
-                    :ok
+                perform_rate_check(max, window_ms, key, frame)
+            end
+          end
 
-                  {:error, :rate_limited, retry_after} ->
-                    error = %Anubis.MCP.Error{
-                      code: -32_029,
-                      message: "Rate limited. Try again in #{retry_after}ms",
-                      data: %{retry_after_ms: retry_after}
-                    }
+          defp perform_rate_check(max, window_ms, key, frame) do
+            case Ectomancer.RateLimiter.check(max: max, window_ms: window_ms, key: key) do
+              :ok ->
+                :ok
 
-                    {:error, error, frame}
-                end
+              {:error, :rate_limited, retry_after} ->
+                error = %Anubis.MCP.Error{
+                  code: -32_029,
+                  message: "Rate limited. Try again in #{retry_after}ms",
+                  data: %{retry_after_ms: retry_after}
+                }
+
+                {:error, error, frame}
             end
           end
 


### PR DESCRIPTION
Closes [#93](https://github.com/GustavoZiaugra/ectomancer/issues/93)

Extracts the inner `case` from `check_rate_limit/2` into a new `perform_rate_check/4` helper to reduce nesting depth.

- `mix credo --strict` — 0 issues
- `mix test` — 634 passed