### PR TITLE
Fix: add @doc to Plug.call/2 to resolve hidden function doc warning

### DIFF
--- a/lib/ectomancer/plug.ex
+++ b/lib/ectomancer/plug.ex
@@ -75,6 +75,14 @@ if Code.ensure_loaded?(Plug) do
       }
     end
 
+    @doc """
+    Handles the MCP request by extracting the actor from the connection and
+    delegating to the Anubis StreamableHTTP transport plug.
+
+    Calls `extract_actor/1` to resolve the actor, then either rejects with
+    401 (if `{:error, _}` returned) or stores the actor in
+    `conn.assigns[:ectomancer_actor]` and forwards to Anubis.
+    """
     @impl Plug
     def call(conn, %{anubis_state: anubis_state}) do
       actor = extract_actor(conn)


### PR DESCRIPTION
`Ectomancer.Plug.call/2` was implicitly hidden in generated docs, causing a warning when referenced from `Ectomancer`'s moduledoc. Added an explicit `@doc` to make the function visible in documentation.