### PR TITLE
change: Add :telemetry events for tools, repo, auth, and rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,36 @@ config :ectomancer, :rate_limits,
   per_tool: [search_users: [max_requests: 10, time_window_ms: 60_000]]
 ```
 
+### Telemetry
+
+Ectomancer emits `:telemetry` events for monitoring, observability, and debugging.
+Events are enabled by default. Disable by setting `telemetry: false`:
+
+```elixir
+config :ectomancer, telemetry: false
+```
+
+**Events emitted:**
+
+| Event | When | Measurements | Metadata |
+|-------|------|-------------|----------|
+| `[:ectomancer, :tool, :start]` | Tool execution begins | `system_time` | `:tool` |
+| `[:ectomancer, :tool, :stop]` | Tool execution ends | `duration` | `:tool` |
+| `[:ectomancer, :tool, :exception]` | Tool handler raises | `duration` | `:tool` |
+| `[:ectomancer, :repo, :start]` | CRUD operation begins | `system_time` | `:action`, `:schema` |
+| `[:ectomancer, :repo, :stop]` | CRUD operation ends | `duration` | `:action`, `:schema` |
+| `[:ectomancer, :repo, :exception]` | Repo operation raises | `duration` | `:action`, `:schema` |
+| `[:ectomancer, :authorization, :denied]` | Auth check fails | (none) | `:actor`, `:action`, `:handler` |
+| `[:ectomancer, :rate_limit, :exceeded]` | Rate limit exceeded | (none) | `:key`, `:window_ms` |
+
+**Example: Attaching a handler**
+
+```elixir
+:telemetry.attach("ectomancer-logger", [:ectomancer, :tool, :stop], fn _name, measurements, metadata, _config ->
+  IO.puts("Tool #{metadata.tool} completed in #{System.convert_time_unit(measurements.duration, :native, :millisecond)}ms")
+end, nil)
+```
+
 ### Multi-repo
 
 ```elixir

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -101,12 +101,12 @@ defmodule Ectomancer.Authorization do
   defp do_check(handler, actor, action) when is_function(handler, 2) do
     case handler.(actor, action) do
       true -> :ok
-      false -> {:error, "Unauthorized access to #{action}"}
+      false -> deny(actor, action, handler, "Unauthorized access to #{action}")
       {:ok, true} -> :ok
-      {:ok, false} -> {:error, "Unauthorized access to #{action}"}
+      {:ok, false} -> deny(actor, action, handler, "Unauthorized access to #{action}")
       {:ok, :scoped, _scope_fn} = scoped -> scoped
-      {:error, reason} -> {:error, reason}
-      _ -> {:error, "Authorization check failed"}
+      {:error, reason} -> deny(actor, action, handler, reason)
+      _ -> deny(actor, action, handler, "Authorization check failed")
     end
   end
 
@@ -114,7 +114,7 @@ defmodule Ectomancer.Authorization do
     if Code.ensure_loaded?(module) do
       call_policy_module(module, actor, action)
     else
-      {:error, "Policy module #{inspect(module)} not found"}
+      deny(actor, action, module, "Policy module #{inspect(module)} not found")
     end
   end
 
@@ -122,12 +122,17 @@ defmodule Ectomancer.Authorization do
     if Code.ensure_loaded?(module) do
       call_policy_module(module, actor, action, opts)
     else
-      {:error, "Policy module #{inspect(module)} not found"}
+      deny(actor, action, module, "Policy module #{inspect(module)} not found")
     end
   end
 
-  defp do_check(handler, _actor, action) do
-    {:error, "Invalid authorization handler for #{action}: #{inspect(handler)}"}
+  defp do_check(handler, actor, action) do
+    deny(
+      actor,
+      action,
+      handler,
+      "Invalid authorization handler for #{action}: #{inspect(handler)}"
+    )
   end
 
   defp call_policy_module(module, actor, action, opts \\ []) do
@@ -142,5 +147,10 @@ defmodule Ectomancer.Authorization do
       true ->
         {:error, "Policy module #{inspect(module)} does not implement authorize/2 or authorize/3"}
     end
+  end
+
+  defp deny(actor, action, handler, reason) do
+    Ectomancer.Telemetry.auth_denied(actor, action, handler)
+    {:error, reason}
   end
 end

--- a/lib/ectomancer/rate_limiter.ex
+++ b/lib/ectomancer/rate_limiter.ex
@@ -95,6 +95,7 @@ defmodule Ectomancer.RateLimiter do
           window_ms
         end
 
+      Ectomancer.Telemetry.rate_limited(key, window_ms)
       {:error, :rate_limited, retry_after}
     end
   end

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -62,24 +62,28 @@ if Code.ensure_loaded?(Ecto) do
     """
     @spec list(module(), map(), keyword()) :: {:ok, [struct()]} | {:error, any()}
     def list(schema_module, params \\ %{}, opts \\ []) do
-      with_repo(opts, fn repo ->
-        introspection = SchemaIntrospection.analyze(schema_module)
-        {meta_params, filter_params} = extract_meta_params(params)
+      Ectomancer.Telemetry.repo_span(:list, schema_module, fn ->
+        try do
+          with_repo(opts, fn repo ->
+            introspection = SchemaIntrospection.analyze(schema_module)
+            {meta_params, filter_params} = extract_meta_params(params)
 
-        query =
-          schema_module
-          |> build_filter_query(filter_params, introspection.fields)
-          |> apply_scope(Keyword.get(opts, :scope))
-          |> apply_soft_delete_filter(schema_module, meta_params)
-          |> apply_ordering(meta_params, introspection.fields)
-          |> apply_pagination(meta_params, opts)
+            query =
+              schema_module
+              |> build_filter_query(filter_params, introspection.fields)
+              |> apply_scope(Keyword.get(opts, :scope))
+              |> apply_soft_delete_filter(schema_module, meta_params)
+              |> apply_ordering(meta_params, introspection.fields)
+              |> apply_pagination(meta_params, opts)
 
-        results = repo.all(query)
-        {:ok, maybe_preload(repo, results, opts)}
+            results = repo.all(query)
+            {:ok, maybe_preload(repo, results, opts)}
+          end)
+        rescue
+          DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
+          e -> {:error, {:unexpected, "List failed: #{Exception.message(e)}"}}
+        end
       end)
-    rescue
-      DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
-      e -> {:error, {:unexpected, "List failed: #{Exception.message(e)}"}}
     end
 
     @doc """
@@ -98,16 +102,20 @@ if Code.ensure_loaded?(Ecto) do
     """
     @spec get(module(), map(), keyword()) :: {:ok, struct() | nil} | {:error, any()}
     def get(schema_module, params, opts \\ []) do
-      with {:ok, repo} <- get_repo(opts),
-           {:ok, pk_values} <- extract_pk_for_get(schema_module, params) do
-        result = fetch_single_record(repo, schema_module, pk_values, opts)
-        handle_get_result(repo, schema_module, params, result, opts)
-      end
-    rescue
-      Ecto.NoResultsError -> {:error, :not_found}
-      Ecto.StaleEntryError -> {:error, :stale_entry}
-      DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
-      e -> {:error, {:unexpected, "GET failed: #{Exception.message(e)}"}}
+      Ectomancer.Telemetry.repo_span(:get, schema_module, fn ->
+        try do
+          with {:ok, repo} <- get_repo(opts),
+               {:ok, pk_values} <- extract_pk_for_get(schema_module, params) do
+            result = fetch_single_record(repo, schema_module, pk_values, opts)
+            handle_get_result(repo, schema_module, params, result, opts)
+          end
+        rescue
+          Ecto.NoResultsError -> {:error, :not_found}
+          Ecto.StaleEntryError -> {:error, :stale_entry}
+          DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
+          e -> {:error, {:unexpected, "GET failed: #{Exception.message(e)}"}}
+        end
+      end)
     end
 
     defp handle_get_result(repo, schema_module, params, result, opts) do
@@ -140,28 +148,31 @@ if Code.ensure_loaded?(Ecto) do
     """
     @spec create(module(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t()}
     def create(schema_module, params, opts \\ []) do
-      with_repo(opts, fn repo ->
-        struct = struct(schema_module)
-        attrs = normalize_params(params || %{}, schema_module)
+      Ectomancer.Telemetry.repo_span(:create, schema_module, fn ->
+        try do
+          with_repo(opts, fn repo ->
+            struct = struct(schema_module)
+            attrs = normalize_params(params || %{}, schema_module)
 
-        # Use the schema's changeset function if available, otherwise fallback to cast
-        changeset =
-          if function_exported?(schema_module, :changeset, 2) do
-            schema_module.changeset(struct, attrs)
-          else
-            writable = writable_fields(schema_module)
-            Ecto.Changeset.cast(struct, attrs, writable)
-          end
+            changeset =
+              if function_exported?(schema_module, :changeset, 2) do
+                schema_module.changeset(struct, attrs)
+              else
+                writable = writable_fields(schema_module)
+                Ecto.Changeset.cast(struct, attrs, writable)
+              end
 
-        case repo.insert(changeset) do
-          {:ok, record} -> {:ok, record}
-          {:error, changeset} -> {:error, changeset}
+            case repo.insert(changeset) do
+              {:ok, record} -> {:ok, record}
+              {:error, changeset} -> {:error, changeset}
+            end
+          end)
+        rescue
+          DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
+          Ecto.StaleEntryError -> {:error, :stale_entry}
+          e -> {:error, {:unexpected, "Create failed: #{Exception.message(e)}"}}
         end
       end)
-    rescue
-      DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
-      Ecto.StaleEntryError -> {:error, :stale_entry}
-      e -> {:error, {:unexpected, "Create failed: #{Exception.message(e)}"}}
     end
 
     @doc """
@@ -178,15 +189,20 @@ if Code.ensure_loaded?(Ecto) do
     """
     @spec update(module(), map()) :: {:ok, struct()} | {:error, Ecto.Changeset.t() | :not_found}
     def update(schema_module, params, opts \\ []) do
-      with {:ok, repo} <- get_repo(opts),
-           {:ok, pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params || %{}),
-           {:ok, record} <- fetch_single_record(repo, schema_module, pk_values, opts) do
-        perform_update(repo, schema_module, record, params || %{}, pk_fields)
-      end
-    rescue
-      DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
-      Ecto.StaleEntryError -> {:error, :stale_entry}
-      e -> {:error, {:unexpected, "Update failed: #{Exception.message(e)}"}}
+      Ectomancer.Telemetry.repo_span(:update, schema_module, fn ->
+        try do
+          with {:ok, repo} <- get_repo(opts),
+               {:ok, pk_fields, pk_values} <-
+                 extract_pk_for_mutation(schema_module, params || %{}),
+               {:ok, record} <- fetch_single_record(repo, schema_module, pk_values, opts) do
+            perform_update(repo, schema_module, record, params || %{}, pk_fields)
+          end
+        rescue
+          DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
+          Ecto.StaleEntryError -> {:error, :stale_entry}
+          e -> {:error, {:unexpected, "Update failed: #{Exception.message(e)}"}}
+        end
+      end)
     end
 
     @doc """
@@ -203,15 +219,19 @@ if Code.ensure_loaded?(Ecto) do
     """
     @spec destroy(module(), map()) :: {:ok, struct()} | {:error, :not_found | any()}
     def destroy(schema_module, params, opts \\ []) do
-      with {:ok, repo} <- get_repo(opts),
-           {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),
-           {:ok, record} <- fetch_single_record(repo, schema_module, pk_values, opts) do
-        perform_destroy(repo, schema_module, record)
-      end
-    rescue
-      DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
-      Ecto.StaleEntryError -> {:error, :stale_entry}
-      e -> {:error, {:unexpected, "Destroy failed: #{Exception.message(e)}"}}
+      Ectomancer.Telemetry.repo_span(:destroy, schema_module, fn ->
+        try do
+          with {:ok, repo} <- get_repo(opts),
+               {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),
+               {:ok, record} <- fetch_single_record(repo, schema_module, pk_values, opts) do
+            perform_destroy(repo, schema_module, record)
+          end
+        rescue
+          DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
+          Ecto.StaleEntryError -> {:error, :stale_entry}
+          e -> {:error, {:unexpected, "Destroy failed: #{Exception.message(e)}"}}
+        end
+      end)
     end
 
     @doc """
@@ -229,21 +249,25 @@ if Code.ensure_loaded?(Ecto) do
     @spec restore(module(), map()) ::
             {:ok, struct()} | {:error, :not_found | :not_soft_deletable | any()}
     def restore(schema_module, params, opts \\ []) do
-      with {:ok, repo} <- get_repo(opts),
-           {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),
-           {:ok, record} <- fetch_single_record(repo, schema_module, pk_values, opts) do
-        sd_field = SchemaIntrospection.soft_delete_field(schema_module)
+      Ectomancer.Telemetry.repo_span(:restore, schema_module, fn ->
+        try do
+          with {:ok, repo} <- get_repo(opts),
+               {:ok, _pk_fields, pk_values} <- extract_pk_for_mutation(schema_module, params),
+               {:ok, record} <- fetch_single_record(repo, schema_module, pk_values, opts) do
+            sd_field = SchemaIntrospection.soft_delete_field(schema_module)
 
-        if sd_field do
-          perform_restore(repo, record, sd_field)
-        else
-          {:error, :not_soft_deletable}
+            if sd_field do
+              perform_restore(repo, record, sd_field)
+            else
+              {:error, :not_soft_deletable}
+            end
+          end
+        rescue
+          DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
+          Ecto.StaleEntryError -> {:error, :stale_entry}
+          e -> {:error, {:unexpected, "Restore failed: #{Exception.message(e)}"}}
         end
-      end
-    rescue
-      DBConnection.ConnectionError -> {:error, {:db, "connection_lost"}}
-      Ecto.StaleEntryError -> {:error, :stale_entry}
-      e -> {:error, {:unexpected, "Restore failed: #{Exception.message(e)}"}}
+      end)
     end
 
     # Private functions

--- a/lib/ectomancer/telemetry.ex
+++ b/lib/ectomancer/telemetry.ex
@@ -1,0 +1,60 @@
+defmodule Ectomancer.Telemetry do
+  @moduledoc false
+
+  @tool_event [:ectomancer, :tool]
+  @repo_event [:ectomancer, :repo]
+  @auth_denied_event [:ectomancer, :authorization, :denied]
+  @rate_limited_event [:ectomancer, :rate_limit, :exceeded]
+
+  @doc false
+  def enabled?, do: Application.get_env(:ectomancer, :telemetry, true)
+
+  @doc false
+  def tool_span(tool_name, fun) do
+    if enabled?() do
+      :telemetry.span(@tool_event, %{tool: tool_name}, fn ->
+        result = fun.()
+        {result, %{tool: tool_name}}
+      end)
+    else
+      fun.()
+    end
+  end
+
+  @doc false
+  def repo_span(action, schema, fun) do
+    if enabled?() do
+      :telemetry.span(@repo_event, %{action: action, schema: schema}, fn ->
+        result = fun.()
+        {result, %{action: action, schema: schema}}
+      end)
+    else
+      fun.()
+    end
+  end
+
+  @doc false
+  def auth_denied(actor, action, handler) do
+    if enabled?() do
+      :telemetry.execute(@auth_denied_event, %{}, %{
+        actor: actor,
+        action: action,
+        handler: inspect(handler)
+      })
+    end
+
+    :ok
+  end
+
+  @doc false
+  def rate_limited(key, window_ms) do
+    if enabled?() do
+      :telemetry.execute(@rate_limited_event, %{}, %{
+        key: inspect(key),
+        window_ms: window_ms
+      })
+    end
+
+    :ok
+  end
+end

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -165,33 +165,35 @@ if Code.ensure_loaded?(Ecto) do
           # only return {:ok, _} - the compiler can't track types through this function
           @dialyzer {:nowarn_function, do_execute: 5}
           defp do_execute(handler, params, scope, actor, frame) do
-            result =
-              cond do
-                is_function(handler, 3) ->
-                  handler.(params, actor, scope)
+            Ectomancer.Telemetry.tool_span(@tool_name, fn ->
+              result =
+                cond do
+                  is_function(handler, 3) ->
+                    handler.(params, actor, scope)
 
-                is_function(handler, 2) ->
-                  handler.(params, actor)
+                  is_function(handler, 2) ->
+                    handler.(params, actor)
 
-                true ->
-                  raise ArgumentError,
-                        "Handler must be a function of arity 2 or 3, got: #{inspect(handler)}"
+                  true ->
+                    raise ArgumentError,
+                          "Handler must be a function of arity 2 or 3, got: #{inspect(handler)}"
+                end
+
+              case result do
+                {:ok, data} ->
+                  response = %Anubis.Server.Response{
+                    type: :tool,
+                    content: [%{"type" => "text", "text" => inspect(data)}]
+                  }
+
+                  {:reply, response, frame}
+
+                {:error, reason} ->
+                  {code, message, data} = Ectomancer.Tool.format_error(reason)
+                  error = %Anubis.MCP.Error{code: code, message: message, data: data}
+                  {:error, error, frame}
               end
-
-            case result do
-              {:ok, data} ->
-                response = %Anubis.Server.Response{
-                  type: :tool,
-                  content: [%{"type" => "text", "text" => inspect(data)}]
-                }
-
-                {:reply, response, frame}
-
-              {:error, reason} ->
-                {code, message, data} = Ectomancer.Tool.format_error(reason)
-                error = %Anubis.MCP.Error{code: code, message: message, data: data}
-                {:error, error, frame}
-            end
+            end)
           rescue
             e ->
               error = %Anubis.MCP.Error{

--- a/test/ectomancer/telemetry_test.exs
+++ b/test/ectomancer/telemetry_test.exs
@@ -25,8 +25,8 @@ defmodule Ectomancer.TelemetryTest do
     end
   end
 
-  alias TestMCP.Tool.Hello
   alias TestMCP.Tool.Explode
+  alias TestMCP.Tool.Hello
 
   def handle_event(name, measurements, metadata, _config) do
     send(self(), {:telemetry_event, name, measurements, metadata})

--- a/test/ectomancer/telemetry_test.exs
+++ b/test/ectomancer/telemetry_test.exs
@@ -1,0 +1,237 @@
+defmodule Ectomancer.TelemetryTest do
+  use ExUnit.Case
+
+  defmodule TestMCP do
+    use Ectomancer,
+      name: "telemetry-test-mcp",
+      version: "1.0.0"
+
+    tool :hello do
+      description("Say hello")
+      param(:name, :string, required: true)
+
+      handle(fn %{"name" => name}, _actor ->
+        {:ok, "Hello, #{name}!"}
+      end)
+    end
+
+    tool :explode do
+      description("Always raises")
+      param(:reason, :string)
+
+      handle(fn _params, _actor ->
+        raise "boom"
+      end)
+    end
+  end
+
+  alias TestMCP.Tool.Hello
+  alias TestMCP.Tool.Explode
+
+  def handle_event(name, measurements, metadata, _config) do
+    send(self(), {:telemetry_event, name, measurements, metadata})
+  end
+
+  setup do
+    handler_id =
+      :telemetry.attach_many(
+        "ectomancer-telemetry-test",
+        [
+          [:ectomancer, :tool, :start],
+          [:ectomancer, :tool, :stop],
+          [:ectomancer, :tool, :exception],
+          [:ectomancer, :repo, :start],
+          [:ectomancer, :repo, :stop],
+          [:ectomancer, :repo, :exception],
+          [:ectomancer, :authorization, :denied],
+          [:ectomancer, :rate_limit, :exceeded]
+        ],
+        &__MODULE__.handle_event/4,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    :ok
+  end
+
+  describe "tool events" do
+    test "emits start and stop events on successful tool execution" do
+      frame = %{assigns: %{ectomancer_actor: nil}}
+
+      {:reply, _response, _frame} = Hello.execute(%{"name" => "Alice"}, frame)
+
+      assert_received {:telemetry_event, [:ectomancer, :tool, :start], measurements, metadata}
+      assert Map.has_key?(measurements, :system_time)
+      assert metadata[:tool] == "hello"
+
+      assert_received {:telemetry_event, [:ectomancer, :tool, :stop], measurements, metadata}
+      assert Map.has_key?(measurements, :duration)
+      assert metadata[:tool] == "hello"
+    end
+
+    test "emits exception event when tool handler raises" do
+      frame = %{assigns: %{ectomancer_actor: nil}}
+
+      result = Explode.execute(%{}, frame)
+
+      assert {:error, _, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :tool, :exception], measurements, metadata}
+
+      assert Map.has_key?(measurements, :duration)
+      assert metadata[:tool] == "explode"
+    end
+  end
+
+  describe "repo events" do
+    test "emits start and stop events for Repo.list" do
+      result = Ectomancer.Repo.list(Ectomancer.TestRepo)
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :start], measurements, metadata}
+      assert Map.has_key?(measurements, :system_time)
+      assert metadata[:action] == :list
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :stop], measurements, metadata}
+      assert Map.has_key?(measurements, :duration)
+      assert metadata[:action] == :list
+    end
+
+    test "emits start and stop events for Repo.get" do
+      result = Ectomancer.Repo.get(Ectomancer.TestRepo, %{"id" => 1})
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :start], _measurements, metadata}
+      assert metadata[:action] == :get
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :stop], _measurements, metadata}
+      assert metadata[:action] == :get
+    end
+
+    test "emits start and stop events for Repo.create" do
+      result = Ectomancer.Repo.create(Ectomancer.TestRepo, %{})
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :start], _measurements, metadata}
+      assert metadata[:action] == :create
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :stop], _measurements, metadata}
+      assert metadata[:action] == :create
+    end
+
+    test "emits start and stop events for Repo.update" do
+      result = Ectomancer.Repo.update(Ectomancer.TestRepo, %{"id" => 1})
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :start], _measurements, metadata}
+      assert metadata[:action] == :update
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :stop], _measurements, metadata}
+      assert metadata[:action] == :update
+    end
+
+    test "emits start and stop events for Repo.destroy" do
+      result = Ectomancer.Repo.destroy(Ectomancer.TestRepo, %{"id" => 1})
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :start], _measurements, metadata}
+      assert metadata[:action] == :destroy
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :stop], _measurements, metadata}
+      assert metadata[:action] == :destroy
+    end
+
+    test "emits start and stop events for Repo.restore" do
+      result = Ectomancer.Repo.restore(Ectomancer.TestRepo, %{"id" => 1})
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :start], _measurements, metadata}
+      assert metadata[:action] == :restore
+
+      assert_received {:telemetry_event, [:ectomancer, :repo, :stop], _measurements, metadata}
+      assert metadata[:action] == :restore
+    end
+  end
+
+  describe "authorization denied event" do
+    test "emits event when authorization check fails" do
+      handler = fn _actor, _action -> false end
+
+      result = Ectomancer.Authorization.check(%{id: 1}, :list, handler: handler)
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :authorization, :denied], _measurements,
+                       metadata}
+
+      assert metadata[:action] == :list
+      assert metadata[:actor] == %{id: 1}
+    end
+
+    test "emits event for policy module not found" do
+      result = Ectomancer.Authorization.check(%{}, :list, handler: NonExistent.Policy)
+
+      assert {:error, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :authorization, :denied], _measurements,
+                       _metadata}
+    end
+
+    test "does not emit event when authorization passes" do
+      handler = fn _actor, _action -> true end
+
+      result = Ectomancer.Authorization.check(%{}, :list, handler: handler)
+
+      assert :ok == result
+
+      refute_received {:telemetry_event, [:ectomancer, :authorization, :denied], _, _}
+    end
+  end
+
+  describe "rate limit exceeded event" do
+    test "emits event when rate limit is exceeded" do
+      Ectomancer.RateLimiter.reset()
+
+      Ectomancer.RateLimiter.check(max: 1, window_ms: 60_000, key: :telemetry_test)
+      result = Ectomancer.RateLimiter.check(max: 1, window_ms: 60_000, key: :telemetry_test)
+
+      assert {:error, :rate_limited, _} = result
+
+      assert_received {:telemetry_event, [:ectomancer, :rate_limit, :exceeded], _measurements,
+                       metadata}
+
+      assert metadata[:window_ms] == 60_000
+      assert is_binary(metadata[:key])
+    end
+
+    test "does not emit event when rate limit passes" do
+      Ectomancer.RateLimiter.reset()
+
+      result = Ectomancer.RateLimiter.check(max: 1, window_ms: 60_000, key: :pass_test)
+
+      assert :ok == result
+
+      refute_received {:telemetry_event, [:ectomancer, :rate_limit, :exceeded], _, _}
+    end
+  end
+
+  describe "telemetry disabled" do
+    test "does not emit events when telemetry is disabled via config" do
+      Application.put_env(:ectomancer, :telemetry, false)
+
+      handler = fn _actor, _action -> false end
+      Ectomancer.Authorization.check(%{}, :list, handler: handler)
+
+      refute_received {:telemetry_event, [:ectomancer, :authorization, :denied], _, _}
+
+      Application.delete_env(:ectomancer, :telemetry)
+    end
+  end
+end


### PR DESCRIPTION
Closes #107

## Summary

Adds `:telemetry` instrumentation across the stack so users can monitor Ectomancer at runtime via Phoenix LiveDashboard, AppSignal, or custom handlers.

## What changed

### New file
- `lib/ectomancer/telemetry.ex` — Helper module with `tool_span/2`, `repo_span/3`, `auth_denied/3`, `rate_limited/2`, and `enabled?/0` for opt-out

### Modified files
- `lib/ectomancer/tool.ex` — `do_execute/5` in generated tool modules wrapped with `Ectomancer.Telemetry.tool_span/2`
- `lib/ectomancer/repo.ex` — All 6 CRUD functions (`list`, `get`, `create`, `update`, `destroy`, `restore`) wrapped with `Ectomancer.Telemetry.repo_span/3`
- `lib/ectomancer/authorization.ex` — All `do_check` clauses emit `[:ectomancer, :authorization, :denied]` via new `deny/4` helper
- `lib/ectomancer/rate_limiter.ex` — Rate limit exceeded path emits `[:ectomancer, :rate_limit, :exceeded]`

### Tests
- `test/ectomancer/telemetry_test.exs` — 14 tests covering tool start/stop/exception, all repo actions, auth denied, rate limit exceeded, and disabled config

### Events emitted

| Event | When | Measurements | Metadata |
|-------|------|-------------|----------|
| `[:ectomancer, :tool, :start]` | Tool execution begins | `system_time` | `:tool` |
| `[:ectomancer, :tool, :stop]` | Tool execution ends | `duration` | `:tool` |
| `[:ectomancer, :tool, :exception]` | Tool handler raises | `duration` | `:tool`, `:kind`, `:reason`, `:stacktrace` |
| `[:ectomancer, :repo, :start]` | CRUD operation begins | `system_time` | `:action`, `:schema` |
| `[:ectomancer, :repo, :stop]` | CRUD operation ends | `duration` | `:action`, `:schema` |
| `[:ectomancer, :repo, :exception]` | Repo operation raises unhandled | `duration` | `:action`, `:schema` |
| `[:ectomancer, :authorization, :denied]` | Auth check fails | (none) | `:actor`, `:action`, `:handler` |
| `[:ectomancer, :rate_limit, :exceeded]` | Rate limit exceeded | (none) | `:key`, `:window_ms` |

### Opt-out

```elixir
config :ectomancer, telemetry: false
```

## Metrics
- 648 tests passing (634 existing + 14 new)
- 0 credo issues
- Format clean