### PR TITLE
Silence installation/teardown logs during test runs

### DIFF
--- a/lib/ectomancer/igniter.ex
+++ b/lib/ectomancer/igniter.ex
@@ -8,6 +8,10 @@ defmodule Ectomancer.Igniter do
   """
 
   def install(_args, _options) do
-    IO.puts("Installing Ectomancer...")
+    unless Mix.env() == :test do
+      IO.puts("Installing Ectomancer...")
+    end
+
+    :ok
   end
 end

--- a/lib/mix/tasks/ectomancer/teardown.ex
+++ b/lib/mix/tasks/ectomancer/teardown.ex
@@ -33,12 +33,18 @@ defmodule Mix.Tasks.Ectomancer.Teardown do
   @impl Mix.Task
   def run(_args) do
     Mix.Task.run("compile")
-    Mix.shell().info("\n🧹 Tearing down Ectomancer...")
+
+    unless Mix.env() == :test do
+      Mix.shell().info("\n🧹 Tearing down Ectomancer...")
+    end
 
     app_name = detect_app_name()
 
     unless anything_to_cleanup?(app_name) do
-      Mix.shell().info("\n✅ Nothing to clean up — Ectomancer is not installed.")
+      unless Mix.env() == :test do
+        Mix.shell().info("\n✅ Nothing to clean up — Ectomancer is not installed.")
+      end
+
       exit({:shutdown, 1})
     end
 


### PR DESCRIPTION
Silences the noisy `IO.puts`/`Mix.shell().info` output that appears when running the full test suite:

```
Installing Ectomancer...
🧹 Tearing down Ectomancer...
✅ Nothing to clean up — Ectomancer is not installed.
```

**Fix:** Wrap output calls in `unless Mix.env() == :test` so real users still see them, but tests run clean.

**Files:**
- `lib/ectomancer/igniter.ex` — wrap `IO.puts` in test check, return `:ok` explicitly
- `lib/mix/tasks/ectomancer/teardown.ex` — wrap banner `Mix.shell().info` calls in test check

648 passing, clean output.