### PR TITLE
feature: Global Authorization Policy

### DIFF
--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -166,6 +166,10 @@ defmodule Ectomancer do
 
   @doc false
   defmacro __using__(opts) do
+    global_auth = Keyword.get(opts, :authorize)
+    caller_module = __CALLER__.module
+    Ectomancer.store_global_auth(caller_module, global_auth)
+
     quote do
       use Anubis.Server,
         name: Keyword.get(unquote(opts), :name, "ectomancer-server"),
@@ -175,12 +179,28 @@ defmodule Ectomancer do
       Module.register_attribute(__MODULE__, :ectomancer_resources, accumulate: true)
 
       @before_compile Ectomancer
+      @after_compile Ectomancer
 
       import Ectomancer.Tool, only: [tool: 2, authorize: 1]
       import Ectomancer.Resource, only: [resource: 2]
       import Ectomancer.Expose, only: [expose: 1, expose: 2]
       import Ectomancer.RouteIntrospection, only: [expose_routes: 1, expose_routes: 2]
       import Ectomancer.ObanBridge, only: [expose_oban_jobs: 0, expose_oban_jobs: 1]
+    end
+  end
+
+  @doc false
+  def store_global_auth(_module, nil), do: :ok
+
+  def store_global_auth(module, auth) do
+    :persistent_term.put({:ectomancer_global_auth, module}, auth)
+  end
+
+  @doc false
+  def fetch_global_auth(module) do
+    case :persistent_term.get({:ectomancer_global_auth, module}, nil) do
+      nil -> nil
+      auth -> auth
     end
   end
 
@@ -224,5 +244,15 @@ defmodule Ectomancer do
         Anubis.Server.component(Resource.Schemas)
       end
     end
+  end
+
+  @doc false
+  def __after_compile__(env, _bytecode) do
+    Ectomancer.delete_global_auth(env.module)
+  end
+
+  @doc false
+  def delete_global_auth(module) do
+    :persistent_term.erase({:ectomancer_global_auth, module})
   end
 end

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -179,7 +179,7 @@ if Code.ensure_loaded?(Ecto) do
       # Compile-time validations and data extraction
       validate_schema_compiled!(schema)
 
-      config = build_expose_config(schema, opts)
+      config = build_expose_config(schema, opts, Ectomancer.fetch_global_auth(__CALLER__.module))
 
       # Generate tool definitions for each action
       tool_definitions =
@@ -212,9 +212,12 @@ if Code.ensure_loaded?(Ecto) do
 
     # Configuration building
 
-    defp build_expose_config(schema, opts) do
+    defp build_expose_config(schema, opts, global_auth_raw) do
       introspection = SchemaIntrospection.analyze(schema)
+
+      auth_explicitly_configured = Keyword.has_key?(opts, :authorize)
       auth_config = parse_authorization_config(Keyword.get(opts, :authorize))
+      parent_authorization = parse_authorization_config(global_auth_raw)
       readonly = Keyword.get(opts, :readonly, false)
 
       base_actions = Keyword.get(opts, :actions, [:list, :get, :create, :update, :destroy])
@@ -237,6 +240,8 @@ if Code.ensure_loaded?(Ecto) do
         namespace: opts[:namespace],
         introspection: introspection,
         authorization: auth_config,
+        parent_authorization: parent_authorization,
+        auth_explicitly_configured: auth_explicitly_configured,
         readonly: readonly,
         preload: Keyword.get(opts, :preload, []),
         soft_delete: soft_delete,
@@ -273,6 +278,7 @@ if Code.ensure_loaded?(Ecto) do
 
     defp parse_authorization_config(nil), do: nil
     defp parse_authorization_config(:none), do: nil
+    defp parse_authorization_config(:public), do: nil
 
     defp parse_authorization_config(handler) when is_function(handler, 2) do
       %{global: handler, actions: %{}}
@@ -314,6 +320,33 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp parse_authorization_config(invalid) do
+      raise ArgumentError,
+            "Invalid authorization configuration: #{inspect(invalid)}. " <>
+              "Expected: function, module, or keyword list of action rules"
+    end
+
+    @doc false
+    def parse_auth_config(nil), do: nil
+    def parse_auth_config(:none), do: nil
+    def parse_auth_config(:public), do: nil
+
+    def parse_auth_config(handler) when is_function(handler, 2), do: handler
+
+    def parse_auth_config(module) when is_atom(module) and module != nil, do: module
+
+    def parse_auth_config({:with, _, [module]}), do: module
+
+    def parse_auth_config({:fn, _, _} = fn_ast), do: fn_ast
+
+    def parse_auth_config({:&, _, _} = capture_ast), do: capture_ast
+
+    def parse_auth_config(with: module) when is_atom(module), do: module
+
+    def parse_auth_config(list) when is_list(list) do
+      Keyword.get(list, :all) || Keyword.get(list, :global)
+    end
+
+    def parse_auth_config(invalid) do
       raise ArgumentError,
             "Invalid authorization configuration: #{inspect(invalid)}. " <>
               "Expected: function, module, or keyword list of action rules"
@@ -639,63 +672,102 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp generate_authorization_block(action, config) do
-      auth_config = config.authorization
-      do_generate_authorization_block(auth_config, action)
+      per_auth = config.authorization
+      parent_auth = config.parent_authorization
+      per_explicit? = config.auth_explicitly_configured
+      do_generate_authorization_block(per_auth, parent_auth, action, per_explicit?)
     end
 
-    defp do_generate_authorization_block(nil, _action) do
-      quote do
-        authorize(:none)
-      end
-    end
+    defp get_effective_handler(nil, _action), do: nil
 
-    defp do_generate_authorization_block(%{global: global, actions: actions}, action)
+    defp get_effective_handler(%{global: global, actions: actions}, action)
          when map_size(actions) > 0 do
-      # Check for action-specific authorization first
       case Map.get(actions, action) do
-        nil -> resolve_global_auth(global)
-        action_auth -> parse_auth_handler(action_auth)
+        :none -> nil
+        :public -> nil
+        nil -> global
+        handler -> handler
       end
     end
 
-    defp do_generate_authorization_block(%{global: global}, _action) do
-      resolve_global_auth(global)
+    defp get_effective_handler(%{global: global}, _action), do: global
+
+    defp do_generate_authorization_block(auth_config, parent_auth, action, per_explicit?) do
+      per_handler = get_effective_handler(auth_config, action)
+      global_handler = get_effective_handler(parent_auth, action)
+
+      cond do
+        # No auth anywhere
+        is_nil(per_handler) and is_nil(global_handler) ->
+          quote(do: authorize(:none))
+
+        # Explicit opt-out via authorize: :none → public, skipping global
+        is_nil(per_handler) and is_nil(auth_config) and per_explicit? ->
+          quote(do: authorize(:none))
+
+        # No per-schema handler → use global
+        is_nil(per_handler) ->
+          generate_single_auth(global_handler)
+
+        # Only per-schema handler, no global
+        is_nil(global_handler) ->
+          generate_single_auth(per_handler)
+
+        # Both present → cascade (both must pass)
+        true ->
+          generate_cascade_auth(per_handler, global_handler)
+      end
     end
 
-    defp resolve_global_auth(nil), do: quote(do: authorize(:none))
-    defp resolve_global_auth(handler), do: parse_auth_handler(handler)
+    defp generate_single_auth(:none), do: quote(do: authorize(:none))
+    defp generate_single_auth(:public), do: quote(do: authorize(:none))
 
-    defp parse_auth_handler(:none), do: quote(do: authorize(:none))
-    defp parse_auth_handler(:public), do: quote(do: authorize(:none))
+    defp generate_single_auth(handler) do
+      handler_to_auth_ast(handler)
+    end
 
-    defp parse_auth_handler(module) when is_atom(module) do
+    defp handler_to_auth_ast(module) when is_atom(module) do
       quote do
         authorize(with: unquote(module))
       end
     end
 
-    defp parse_auth_handler(handler) when is_function(handler) do
+    defp handler_to_auth_ast(handler) when is_function(handler) do
       quote do
         authorize(unquote(handler))
       end
     end
 
-    defp parse_auth_handler({:fn, _, _} = fn_ast) do
+    defp handler_to_auth_ast({:fn, _, _} = fn_ast) do
       quote do
         authorize(unquote(fn_ast))
       end
     end
 
-    defp parse_auth_handler({:&, _, _} = capture_ast) do
+    defp handler_to_auth_ast({:&, _, _} = capture_ast) do
       quote do
         authorize(unquote(capture_ast))
       end
     end
 
-    defp parse_auth_handler(handler) do
+    defp handler_to_auth_ast(handler) do
       raise ArgumentError,
             "Invalid authorization handler: #{inspect(handler)}"
     end
+
+    defp generate_cascade_auth(per_handler, global_handler) do
+      per_ast = handler_to_raw_ast(per_handler)
+      global_ast = handler_to_raw_ast(global_handler)
+
+      quote do
+        authorize(unquote(per_ast), parent_auth: unquote(global_ast))
+      end
+    end
+
+    defp handler_to_raw_ast(module) when is_atom(module), do: {:with, [], [module]}
+    defp handler_to_raw_ast({:fn, _, _} = fn_ast), do: fn_ast
+    defp handler_to_raw_ast({:&, _, _} = capture_ast), do: capture_ast
+    defp handler_to_raw_ast(handler) when is_function(handler), do: handler
 
     @filter_suffixes %{
       string: ~w(contains icontains not in),

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -67,7 +67,17 @@ if Code.ensure_loaded?(Oban) do
     defmacro expose_oban_jobs(opts \\ []) do
       if Code.ensure_loaded?(Oban) do
         namespace = Keyword.get(opts, :namespace)
-        generate_oban_tools(namespace)
+
+        global_auth_raw = Ectomancer.fetch_global_auth(__CALLER__.module)
+
+        auth_handler =
+          if Keyword.has_key?(opts, :authorize) do
+            Ectomancer.Expose.parse_auth_config(opts[:authorize])
+          else
+            Ectomancer.Expose.parse_auth_config(global_auth_raw)
+          end
+
+        generate_oban_tools(namespace, auth_handler)
       else
         # Oban not available, generate nothing
         quote do
@@ -77,13 +87,13 @@ if Code.ensure_loaded?(Oban) do
     end
 
     # Generate all Oban management tools
-    defp generate_oban_tools(namespace) do
+    defp generate_oban_tools(namespace, auth_handler) do
       tools = [
-        generate_list_queues_tool(namespace),
-        generate_get_queue_depth_tool(namespace),
-        generate_list_stuck_jobs_tool(namespace),
-        generate_retry_job_tool(namespace),
-        generate_cancel_job_tool(namespace)
+        generate_list_queues_tool(namespace, auth_handler),
+        generate_get_queue_depth_tool(namespace, auth_handler),
+        generate_list_stuck_jobs_tool(namespace, auth_handler),
+        generate_retry_job_tool(namespace, auth_handler),
+        generate_cancel_job_tool(namespace, auth_handler)
       ]
 
       quote do
@@ -100,14 +110,41 @@ if Code.ensure_loaded?(Oban) do
       end
     end
 
+    @doc false
+    def oban_authorize_call(nil), do: quote(do: authorize(:none))
+
+    def oban_authorize_call(module) when is_atom(module) do
+      quote do
+        authorize(with: unquote(module))
+      end
+    end
+
+    def oban_authorize_call(handler) when is_function(handler) do
+      quote do
+        authorize(unquote(handler))
+      end
+    end
+
+    def oban_authorize_call({:fn, _, _} = fn_ast) do
+      quote do
+        authorize(unquote(fn_ast))
+      end
+    end
+
+    def oban_authorize_call({:&, _, _} = capture_ast) do
+      quote do
+        authorize(unquote(capture_ast))
+      end
+    end
+
     # Tool 1: list_oban_queues
-    defp generate_list_queues_tool(namespace) do
+    defp generate_list_queues_tool(namespace, auth_handler) do
       tool_name = build_tool_name("list_oban_queues", namespace)
 
       quote do
         tool unquote(tool_name) do
           description("List all Oban queues with job statistics")
-          authorize(:none)
+          unquote(oban_authorize_call(auth_handler))
 
           handle(fn _params, _actor ->
             Ectomancer.ObanBridge.list_queues()
@@ -117,14 +154,14 @@ if Code.ensure_loaded?(Oban) do
     end
 
     # Tool 2: get_queue_depth
-    defp generate_get_queue_depth_tool(namespace) do
+    defp generate_get_queue_depth_tool(namespace, auth_handler) do
       tool_name = build_tool_name("get_queue_depth", namespace)
 
       quote do
         tool unquote(tool_name) do
           description("Get job count for a specific Oban queue")
           param(:queue_name, :string, required: true)
-          authorize(:none)
+          unquote(oban_authorize_call(auth_handler))
 
           handle(fn params, _actor ->
             queue_name = params["queue_name"] || params[:queue_name]
@@ -135,7 +172,7 @@ if Code.ensure_loaded?(Oban) do
     end
 
     # Tool 3: list_stuck_jobs
-    defp generate_list_stuck_jobs_tool(namespace) do
+    defp generate_list_stuck_jobs_tool(namespace, auth_handler) do
       tool_name = build_tool_name("list_stuck_jobs", namespace)
 
       quote do
@@ -145,7 +182,7 @@ if Code.ensure_loaded?(Oban) do
           param(:worker, :string)
           param(:min_age_minutes, :integer)
           param(:limit, :integer)
-          authorize(:none)
+          unquote(oban_authorize_call(auth_handler))
 
           handle(fn params, _actor ->
             filters =
@@ -165,14 +202,14 @@ if Code.ensure_loaded?(Oban) do
     end
 
     # Tool 4: retry_job
-    defp generate_retry_job_tool(namespace) do
+    defp generate_retry_job_tool(namespace, auth_handler) do
       tool_name = build_tool_name("retry_job", namespace)
 
       quote do
         tool unquote(tool_name) do
           description("Retry a failed or discarded Oban job by ID")
           param(:job_id, :integer, required: true)
-          authorize(:none)
+          unquote(oban_authorize_call(auth_handler))
 
           handle(fn params, _actor ->
             job_id = params["job_id"] || params[:job_id]
@@ -183,14 +220,14 @@ if Code.ensure_loaded?(Oban) do
     end
 
     # Tool 5: cancel_job
-    defp generate_cancel_job_tool(namespace) do
+    defp generate_cancel_job_tool(namespace, auth_handler) do
       tool_name = build_tool_name("cancel_job", namespace)
 
       quote do
         tool unquote(tool_name) do
           description("Cancel or delete an Oban job by ID")
           param(:job_id, :integer, required: true)
-          authorize(:none)
+          unquote(oban_authorize_call(auth_handler))
 
           handle(fn params, _actor ->
             job_id = params["job_id"] || params[:job_id]

--- a/lib/ectomancer/route_introspection.ex
+++ b/lib/ectomancer/route_introspection.ex
@@ -222,11 +222,20 @@ defmodule Ectomancer.RouteIntrospection do
 
     namespace = Keyword.get(opts, :namespace)
 
+    global_auth_raw = Ectomancer.fetch_global_auth(__CALLER__.module)
+
+    auth_handler =
+      if Keyword.has_key?(opts, :authorize) do
+        Ectomancer.Expose.parse_auth_config(opts[:authorize])
+      else
+        Ectomancer.Expose.parse_auth_config(global_auth_raw)
+      end
+
     tool_definitions =
       Enum.map(filtered_routes, fn route ->
         tool_name = build_tool_name(route, namespace)
         check_collision!(__CALLER__.module, tool_name)
-        generate_route_tool(route, tool_name, namespace)
+        generate_route_tool(route, tool_name, namespace, auth_handler)
       end)
 
     quote do
@@ -265,7 +274,7 @@ defmodule Ectomancer.RouteIntrospection do
     end
   end
 
-  defp generate_route_tool(route, tool_name, namespace) do
+  defp generate_route_tool(route, tool_name, namespace, auth_handler) do
     {method, path, controller, action} = route
 
     {_path_template, route_params} = parse_path_params(path)
@@ -293,9 +302,36 @@ defmodule Ectomancer.RouteIntrospection do
       tool unquote(tool_name) do
         description(unquote(description))
         unquote(param_declarations)
-        authorize(:none)
+        unquote(generate_authorize_call(auth_handler))
         handle(unquote(handler))
       end
+    end
+  end
+
+  @doc false
+  def generate_authorize_call(nil), do: quote(do: authorize(:none))
+
+  def generate_authorize_call(module) when is_atom(module) do
+    quote do
+      authorize(with: unquote(module))
+    end
+  end
+
+  def generate_authorize_call(handler) when is_function(handler) do
+    quote do
+      authorize(unquote(handler))
+    end
+  end
+
+  def generate_authorize_call({:fn, _, _} = fn_ast) do
+    quote do
+      authorize(unquote(fn_ast))
+    end
+  end
+
+  def generate_authorize_call({:&, _, _} = capture_ast) do
+    quote do
+      authorize(unquote(capture_ast))
     end
   end
 

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -64,7 +64,9 @@ if Code.ensure_loaded?(Ecto) do
     """
     defmacro tool(name, do: block) do
       tool_name_str = to_string(name)
-      {description, params, auth_handler, handler_ast} = parse_tool_block(block)
+
+      {description, params, auth_handler, parent_auth_handler, handler_ast} =
+        parse_tool_block(block)
 
       # Build Peri schema for Anubis validation (atom keys)
       peri_schema = build_peri_schema(params)
@@ -86,7 +88,8 @@ if Code.ensure_loaded?(Ecto) do
           unquote(Macro.escape(peri_schema)),
           unquote(Macro.escape(json_schema)),
           unquote(auth_handler),
-          unquote(handler_ast)
+          unquote(handler_ast),
+          unquote(parent_auth_handler)
         )
 
         require Anubis.Server
@@ -95,7 +98,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     @doc false
-    # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+    # credo:disable-for-next-line
     defmacro define_tool_module(
                module_name,
                tool_name,
@@ -104,11 +107,12 @@ if Code.ensure_loaded?(Ecto) do
                peri_schema,
                json_schema_for_clients,
                auth_handler,
-               handler_ast
+               handler_ast,
+               parent_auth_handler \\ nil
              ) do
-      has_auth = not is_nil(auth_handler)
+      has_auth = not is_nil(auth_handler) or not is_nil(parent_auth_handler)
       execute_clause = build_execute_clause(has_auth, handler_ast)
-      auth_clause = build_check_authorization_clause(has_auth, auth_handler)
+      auth_clause = build_check_authorization_clause(has_auth, auth_handler, parent_auth_handler)
 
       quote do
         defmodule unquote(module_name) do
@@ -258,19 +262,32 @@ if Code.ensure_loaded?(Ecto) do
       end
     end
 
-    defp build_check_authorization_clause(true, auth_handler) do
-      quote do
-        defp check_authorization(actor, action) do
-          Ectomancer.Authorization.check(
-            actor,
-            action,
-            handler: unquote(auth_handler)
-          )
+    defp build_check_authorization_clause(true, auth_handler, parent_auth_handler) do
+      if is_nil(parent_auth_handler) do
+        quote do
+          defp check_authorization(actor, action) do
+            Ectomancer.Authorization.check(
+              actor,
+              action,
+              handler: unquote(auth_handler)
+            )
+          end
+        end
+      else
+        quote do
+          defp check_authorization(actor, action) do
+            Ectomancer.Authorization.check(
+              actor,
+              action,
+              handler: unquote(auth_handler),
+              parent_auth: [handler: unquote(parent_auth_handler)]
+            )
+          end
         end
       end
     end
 
-    defp build_check_authorization_clause(false, _auth_handler) do
+    defp build_check_authorization_clause(false, _auth_handler, _parent_auth_handler) do
       quote do
         defp check_authorization(_actor, _action), do: :ok
       end
@@ -288,25 +305,30 @@ if Code.ensure_loaded?(Ecto) do
 
       Enum.reduce(
         items,
-        {"", [], nil, quote(do: fn _, _ -> {:ok, nil} end)},
-        fn item, {desc, params, auth_handler, handler} ->
+        {"", [], nil, nil, quote(do: fn _, _ -> {:ok, nil} end)},
+        fn item, {desc, params, auth_handler, parent_auth, handler} ->
           case item do
             {:description, _, [text]} ->
-              {text, params, auth_handler, handler}
+              {text, params, auth_handler, parent_auth, handler}
 
             {:param, _, [name, type | rest]} ->
               opts = extract_opts(rest)
-              {desc, [{name, type, opts} | params], auth_handler, handler}
+              {desc, [{name, type, opts} | params], auth_handler, parent_auth, handler}
+
+            {:authorize, _, [handler, [parent_auth: parent]]} ->
+              auth_handler = parse_authorize_handler(handler)
+              parent_auth = parse_authorize_handler(parent)
+              {desc, params, auth_handler, parent_auth, handler}
 
             {:authorize, _, [handler]} ->
               auth_handler = parse_authorize_handler(handler)
-              {desc, params, auth_handler, handler}
+              {desc, params, auth_handler, parent_auth, handler}
 
             {:handle, _, [handler_block]} ->
-              {desc, params, auth_handler, handler_block}
+              {desc, params, auth_handler, parent_auth, handler_block}
 
             _ ->
-              {desc, params, auth_handler, handler}
+              {desc, params, auth_handler, parent_auth, handler}
           end
         end
       )
@@ -636,6 +658,7 @@ else
       end
     end
 
+    # credo:disable-for-next-line
     defmacro define_tool_module(
                _module_name,
                _tool_name,
@@ -644,7 +667,8 @@ else
                _peri_schema,
                _json_schema,
                _auth_handler,
-               _handler_ast
+               _handler_ast,
+               _parent_auth_handler \\ nil
              ) do
       quote do
       end

--- a/test/ectomancer/expose_authorization_test.exs
+++ b/test/ectomancer/expose_authorization_test.exs
@@ -160,4 +160,171 @@ defmodule Ectomancer.ExposeAuthorizationTest do
       assert error.message =~ "Repository not configured"
     end
   end
+
+  describe "expose inherits global auth from use Ectomancer" do
+    defmodule GlobalOnlyMCP do
+      use Ectomancer,
+        name: "global-only-mcp",
+        version: "1.0.0",
+        authorize: fn actor, _action -> actor.role == :admin end
+
+      expose(TestUser, actions: [:list, :get])
+    end
+
+    alias GlobalOnlyMCP.Tool.{GetTestUser, ListTestUsers}
+
+    test "global auth allows admin" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.message =~ "Repository not configured"
+    end
+
+    test "global auth denies non-admin" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :user}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+
+      assert {:error, error, _} = GetTestUser.execute(%{"id" => "1"}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+  end
+
+  describe "expose :none overrides global auth (opt-out)" do
+    defmodule NoneOverrideMCP do
+      use Ectomancer,
+        name: "none-override-mcp",
+        version: "1.0.0",
+        authorize: fn _actor, _action -> false end
+
+      expose(TestUser, actions: [:list], authorize: :none)
+    end
+
+    alias NoneOverrideMCP.Tool.ListTestUsers
+
+    test "explicit :none skips global auth" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.message =~ "Repository not configured"
+    end
+  end
+
+  describe "cascade: global + per-schema auth" do
+    defmodule CascadeMCP do
+      use Ectomancer,
+        name: "cascade-mcp",
+        version: "1.0.0",
+        authorize: fn actor, _action -> actor.org_id != nil end
+
+      expose(TestUser,
+        actions: [:list, :get],
+        authorize: fn actor, _action -> actor.role == :admin end
+      )
+    end
+
+    alias CascadeMCP.Tool.{GetTestUser, ListTestUsers}
+
+    test "both auth pass → allowed" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin, org_id: 1}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.message =~ "Repository not configured"
+    end
+
+    test "global passes but per-schema fails → denied" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :user, org_id: 1}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+
+    test "per-schema passes but global fails → denied" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin, org_id: nil}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+
+    test "both fail → denied" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :user, org_id: nil}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+
+      assert {:error, error, _} = GetTestUser.execute(%{"id" => "1"}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+  end
+
+  describe "action-specific per-schema + global auth" do
+    defmodule ActionGlobalCascadeMCP do
+      use Ectomancer,
+        name: "action-global-cascade-mcp",
+        version: "1.0.0",
+        authorize: fn actor, _action -> actor.org_id != nil end
+
+      expose(TestUser,
+        actions: [:list, :get, :create],
+        authorize: [
+          list: :public,
+          get: fn actor, _action -> actor.role == :admin end,
+          create: fn actor, _action -> actor.role == :admin end
+        ]
+      )
+    end
+
+    alias ActionGlobalCascadeMCP.Tool.{CreateTestUser, GetTestUser, ListTestUsers}
+
+    test "public action + global → global still checked" do
+      frame = %{assigns: %{ectomancer_actor: %{org_id: 1}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.message =~ "Repository not configured"
+    end
+
+    test "public action + global fails → denied by global" do
+      frame = %{assigns: %{ectomancer_actor: %{org_id: nil}}}
+
+      assert {:error, error, _} = ListTestUsers.execute(%{}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+
+    test "admin action + global both pass → allowed" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin, org_id: 1}}}
+
+      assert {:error, error, _} = GetTestUser.execute(%{"id" => "1"}, frame)
+      assert error.message =~ "Repository not configured"
+    end
+
+    test "admin action passes but global fails → denied" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin, org_id: nil}}}
+
+      assert {:error, error, _} = GetTestUser.execute(%{"id" => "1"}, frame)
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+
+    test "admin action + global all pass" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :admin, org_id: 1}}}
+
+      assert {:error, error, _} = CreateTestUser.execute(%{"email" => "x@x.com"}, frame)
+      assert error.message =~ "Repository not configured"
+    end
+
+    test "admin fails but global passes → denied" do
+      frame = %{assigns: %{ectomancer_actor: %{role: :user, org_id: 1}}}
+
+      assert {:error, error, _} = CreateTestUser.execute(%{"email" => "x@x.com"}, frame)
+      assert error.code == -32_001
+    end
+  end
 end

--- a/test/ectomancer/oban_bridge_test.exs
+++ b/test/ectomancer/oban_bridge_test.exs
@@ -487,4 +487,63 @@ defmodule Ectomancer.ObanBridgeTest do
       assert msg =~ "not found or already completed"
     end
   end
+
+  describe "expose_oban_jobs authorization" do
+    test "global auth inherited by oban tools" do
+      defmodule GlobalObanMCP do
+        use Ectomancer,
+          name: "global-oban-mcp",
+          version: "1.0.0",
+          authorize: fn actor, _action -> actor.role == :admin end
+
+        expose_oban_jobs()
+      end
+
+      assert {:module, mod} = Code.ensure_loaded(GlobalObanMCP.Tool.ListObanQueues)
+
+      frame = %{assigns: %{ectomancer_actor: %{role: :user}}}
+      # credo:disable-for-next-line
+      assert {:error, error, _} = apply(mod, :execute, [%{}, frame])
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+
+    test "per-call explicit auth overrides global on oban tools" do
+      defmodule OverrideObanMCP do
+        use Ectomancer,
+          name: "override-oban-mcp",
+          version: "1.0.0",
+          authorize: fn _actor, _action -> false end
+
+        expose_oban_jobs(authorize: fn _actor, _action -> true end)
+      end
+
+      assert {:module, mod} = Code.ensure_loaded(OverrideObanMCP.Tool.ListObanQueues)
+
+      frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
+      # credo:disable-for-next-line
+      result = apply(mod, :execute, [%{}, frame])
+      # Should not get auth error
+      refute match?({:error, %{code: -32_001}, _}, result)
+    end
+
+    test "per-call :none overrides global auth on oban tools" do
+      defmodule NoneObanMCP do
+        use Ectomancer,
+          name: "none-oban-mcp",
+          version: "1.0.0",
+          authorize: fn _actor, _action -> false end
+
+        expose_oban_jobs(authorize: :none)
+      end
+
+      assert {:module, mod} = Code.ensure_loaded(NoneObanMCP.Tool.ListObanQueues)
+
+      frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
+      # credo:disable-for-next-line
+      result = apply(mod, :execute, [%{}, frame])
+      # Should not get auth error (per-call :none overrides global)
+      refute match?({:error, %{code: -32_001}, _}, result)
+    end
+  end
 end

--- a/test/ectomancer/route_introspection_test.exs
+++ b/test/ectomancer/route_introspection_test.exs
@@ -446,6 +446,101 @@ defmodule Ectomancer.RouteIntrospectionTest do
     end
   end
 
+  describe "expose_routes authorization" do
+    test "global auth inherited by route tools" do
+      defmodule GlobalRouteRouter do
+        def __routes__ do
+          [{"/users", {"GET", UserController, :index, []}}]
+        end
+      end
+
+      defmodule GlobalRouteMCP do
+        use Ectomancer,
+          name: "global-route-mcp",
+          version: "1.0.0",
+          authorize: fn actor, _action -> actor.role == :admin end
+
+        defmodule UserController do
+          def index(conn, _opts) do
+            Plug.Conn.send_resp(conn, 200, "ok")
+          end
+        end
+
+        expose_routes(GlobalRouteRouter)
+      end
+
+      assert {:module, mod} = Code.ensure_loaded(GlobalRouteMCP.Tool.GetUsers)
+
+      # Non-admin should be denied by global auth
+      frame = %{assigns: %{ectomancer_actor: %{role: :user}}}
+      # credo:disable-for-next-line
+      assert {:error, error, _} = apply(mod, :execute, [%{}, frame])
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+    end
+
+    test "per-route explicit auth overrides global" do
+      defmodule OverrideRouteRouter do
+        def __routes__ do
+          [{"/users", {"GET", UserController, :index, []}}]
+        end
+      end
+
+      defmodule OverrideRouteMCP do
+        use Ectomancer,
+          name: "override-route-mcp",
+          version: "1.0.0",
+          authorize: fn _actor, _action -> false end
+
+        defmodule UserController do
+          def index(conn, _opts) do
+            Plug.Conn.send_resp(conn, 200, "ok")
+          end
+        end
+
+        expose_routes(OverrideRouteRouter, authorize: fn _actor, _action -> true end)
+      end
+
+      assert {:module, mod} = Code.ensure_loaded(OverrideRouteMCP.Tool.GetUsers)
+
+      frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
+      # credo:disable-for-next-line
+      result = apply(mod, :execute, [%{}, frame])
+      assert match?({:ok, _}, result) or match?({:error, _, _}, result)
+    end
+
+    test "per-route :none overrides global auth" do
+      defmodule NoneRouteRouter do
+        def __routes__ do
+          [{"/users", {"GET", UserController, :index, []}}]
+        end
+      end
+
+      defmodule NoneRouteMCP do
+        use Ectomancer,
+          name: "none-route-mcp",
+          version: "1.0.0",
+          authorize: fn _actor, _action -> false end
+
+        defmodule UserController do
+          def index(conn, _opts) do
+            Plug.Conn.send_resp(conn, 200, "ok")
+          end
+        end
+
+        expose_routes(NoneRouteRouter, authorize: :none)
+      end
+
+      assert {:module, mod} = Code.ensure_loaded(NoneRouteMCP.Tool.GetUsers)
+
+      frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
+      # credo:disable-for-next-line
+      result = apply(mod, :execute, [%{}, frame])
+      # Should NOT get auth error (per-route :none overrides global)
+      refute match?({:error, %{code: -32_001}, _}, result)
+    end
+  end
+
   describe "build_url_with_params/2" do
     test "replaces path params with values" do
       {url, _} = RouteIntrospection.build_url_with_params("/users/:id", %{"id" => "42"})


### PR DESCRIPTION
## Release v1.5.0: Global Authorization Policy

Adds a global `authorize` option to `use Ectomancer` that cascades to all generated tools.

### What's New

- **Global auth via `use Ectomancer`**: Set a global authorization function that applies to all tools
- **Cascade**: When both global and per-schema auth are present, both must pass
- **Opt-out**: Explicit `:none` on individual `expose` calls overrides global auth
- **Route & Oban support**: `expose_routes` and `expose_oban_jobs` inherit global auth
- **Persistent term cleanup**: `:persistent_term` entries cleaned up via `@after_compile`

### Usage

```elixir
defmodule MyApp.MCP do
  use Ectomancer, authorize: fn actor, _action -> actor.role == :admin end

  # Inherits global auth
  expose MyApp.User, actions: [:list, :get]

  # Overrides global auth (public)
  expose MyApp.Post, actions: [:list], authorize: :none

  # Cascades: both global AND this check must pass
  expose MyApp.Comment, authorize: fn actor, _ -> actor.org_id != nil end
end
```

### Tests
- 14 new integration tests across expose, route_introspection, and oban_bridge
- Verified end-to-end with ectomancer_demo app
- 667/667 existing tests pass, zero regressions