### PR TITLE
refactor: simplify codebase — extract focused submodules and eliminate duplication

### DIFF
--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -190,18 +190,18 @@ defmodule Ectomancer do
   end
 
   @doc false
-  def store_global_auth(_module, nil), do: :ok
-
   def store_global_auth(module, auth) do
     :persistent_term.put({:ectomancer_global_auth, module}, auth)
   end
 
   @doc false
   def fetch_global_auth(module) do
-    case :persistent_term.get({:ectomancer_global_auth, module}, nil) do
-      nil -> nil
-      auth -> auth
-    end
+    :persistent_term.get({:ectomancer_global_auth, module}, nil)
+  end
+
+  @doc false
+  def delete_global_auth(module) do
+    :persistent_term.erase({:ectomancer_global_auth, module})
   end
 
   @doc false
@@ -213,7 +213,6 @@ defmodule Ectomancer do
         :ok
       end
     else
-      # The resources attribute accumulates entries in reverse order (LIFO)
       resources = Enum.reverse(resources)
 
       quote do
@@ -249,10 +248,5 @@ defmodule Ectomancer do
   @doc false
   def __after_compile__(env, _bytecode) do
     Ectomancer.delete_global_auth(env.module)
-  end
-
-  @doc false
-  def delete_global_auth(module) do
-    :persistent_term.erase({:ectomancer_global_auth, module})
   end
 end

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -153,4 +153,77 @@ defmodule Ectomancer.Authorization do
     Ectomancer.Telemetry.auth_denied(actor, action, handler)
     {:error, reason}
   end
+
+  @doc """
+  Parses an authorization handler into a canonical form.
+
+  Returns the handler value (function, module atom, or AST tuple), or `nil` for no auth.
+  Raises `ArgumentError` for unknown atoms (strict parsing, used for per-tool auth).
+  """
+  @spec parse_handler(any()) :: term() | nil
+  def parse_handler(nil), do: nil
+  def parse_handler(:none), do: nil
+  def parse_handler(:public), do: nil
+
+  def parse_handler(handler) when is_function(handler, 2), do: handler
+
+  def parse_handler({:with, _, [module]}), do: module
+
+  def parse_handler({:fn, _, _} = fn_ast), do: fn_ast
+  def parse_handler({:&, _, _} = capture_ast), do: capture_ast
+
+  def parse_handler(with: module) when is_atom(module), do: module
+
+  def parse_handler([with: module]) when is_atom(module), do: module
+
+  def parse_handler(list) when is_list(list) do
+    Keyword.get(list, :all) || Keyword.get(list, :global)
+  end
+
+  def parse_handler(invalid) do
+    raise ArgumentError,
+          "Invalid authorization handler. Use: authorize(fn actor, action -> ...), authorize(with: Module), or authorize(:none)"
+  end
+
+  @doc """
+  Like `parse_handler/1` but also accepts bare atoms as policy module names.
+  Used for global authorization configs where `MyPolicyModule` is a valid form.
+  """
+  def parse_handler_for_global(module) when is_atom(module) and module != nil, do: module
+  def parse_handler_for_global(handler), do: parse_handler(handler)
+
+  @doc """
+  Generates an AST quote for the `authorize` macro call.
+  """
+  def authorize_to_ast(nil), do: quote(do: authorize(:none))
+  def authorize_to_ast(:none), do: quote(do: authorize(:none))
+
+  def authorize_to_ast(module) when is_atom(module) do
+    quote do
+      authorize(with: unquote(module))
+    end
+  end
+
+  def authorize_to_ast(handler) when is_function(handler) do
+    quote do
+      authorize(unquote(handler))
+    end
+  end
+
+  def authorize_to_ast({:fn, _, _} = fn_ast) do
+    quote do
+      authorize(unquote(fn_ast))
+    end
+  end
+
+  def authorize_to_ast({:&, _, _} = capture_ast) do
+    quote do
+      authorize(unquote(capture_ast))
+    end
+  end
+
+  def authorize_to_ast(invalid) do
+    raise ArgumentError,
+          "Invalid authorization handler AST: #{inspect(invalid)}"
+  end
 end

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -174,7 +174,7 @@ defmodule Ectomancer.Authorization do
 
   def parse_handler(with: module) when is_atom(module), do: module
 
-  def parse_handler([with: module]) when is_atom(module), do: module
+  def parse_handler(with: module) when is_atom(module), do: module
 
   def parse_handler(list) when is_list(list) do
     Keyword.get(list, :all) || Keyword.get(list, :global)

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -180,7 +180,7 @@ defmodule Ectomancer.Authorization do
     Keyword.get(list, :all) || Keyword.get(list, :global)
   end
 
-  def parse_handler(invalid) do
+  def parse_handler(_invalid) do
     raise ArgumentError,
           "Invalid authorization handler. Use: authorize(fn actor, action -> ...), authorize(with: Module), or authorize(:none)"
   end

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -122,6 +122,7 @@ if Code.ensure_loaded?(Ecto) do
     """
 
     alias Ectomancer.SchemaIntrospection
+    alias Ectomancer.Authorization
     alias Ectomancer.Expose.Params
     alias Ectomancer.Expose.Handlers
 
@@ -321,77 +322,27 @@ if Code.ensure_loaded?(Ecto) do
     defp parse_authorization_config(:none), do: nil
     defp parse_authorization_config(:public), do: nil
 
-    defp parse_authorization_config(handler) when is_function(handler, 2) do
-      %{global: handler, actions: %{}}
-    end
-
-    defp parse_authorization_config(module) when is_atom(module) do
-      %{global: module, actions: %{}}
-    end
-
-    defp parse_authorization_config({:with, _, [module]}) do
-      %{global: module, actions: %{}}
-    end
-
-    # Handle inline function AST
-    defp parse_authorization_config({:fn, _, _} = fn_ast) do
-      %{global: fn_ast, actions: %{}}
-    end
-
-    # Handle function capture AST
-    defp parse_authorization_config({:&, _, _} = capture_ast) do
-      %{global: capture_ast, actions: %{}}
-    end
-
-    # Handle [with: Module] syntax for policy modules
-    defp parse_authorization_config(with: module) when is_atom(module) do
-      %{global: module, actions: %{}}
-    end
-
     defp parse_authorization_config(action_rules) when is_list(action_rules) do
       global = Keyword.get(action_rules, :all) || Keyword.get(action_rules, :global)
+      global_handler = if global, do: Authorization.parse_handler_for_global(global), else: nil
 
-      # Convert action rules to map, preserving AST nodes
       actions =
         action_rules
         |> Keyword.drop([:all, :global])
         |> Map.new()
 
-      %{global: global, actions: actions}
+      %{global: global_handler, actions: actions}
     end
 
-    defp parse_authorization_config(invalid) do
-      raise ArgumentError,
-            "Invalid authorization configuration: #{inspect(invalid)}. " <>
-              "Expected: function, module, or keyword list of action rules"
+    defp parse_authorization_config(handler) do
+      %{global: Authorization.parse_handler_for_global(handler), actions: %{}}
     end
 
     @doc false
     def parse_auth_config(nil), do: nil
     def parse_auth_config(:none), do: nil
     def parse_auth_config(:public), do: nil
-
-    def parse_auth_config(handler) when is_function(handler, 2), do: handler
-
-    def parse_auth_config(module) when is_atom(module) and module != nil, do: module
-
-    def parse_auth_config({:with, _, [module]}), do: module
-
-    def parse_auth_config({:fn, _, _} = fn_ast), do: fn_ast
-
-    def parse_auth_config({:&, _, _} = capture_ast), do: capture_ast
-
-    def parse_auth_config(with: module) when is_atom(module), do: module
-
-    def parse_auth_config(list) when is_list(list) do
-      Keyword.get(list, :all) || Keyword.get(list, :global)
-    end
-
-    def parse_auth_config(invalid) do
-      raise ArgumentError,
-            "Invalid authorization configuration: #{inspect(invalid)}. " <>
-              "Expected: function, module, or keyword list of action rules"
-    end
+    def parse_auth_config(handler), do: Authorization.parse_handler_for_global(handler)
 
     defp filter_fields(introspection, opts) do
       only = Keyword.get(opts, :only)

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -121,10 +121,10 @@ if Code.ensure_loaded?(Ecto) do
         config :ectomancer, :repo, MyApp.Repo
     """
 
-    alias Ectomancer.SchemaIntrospection
     alias Ectomancer.Authorization
-    alias Ectomancer.Expose.Params
     alias Ectomancer.Expose.Handlers
+    alias Ectomancer.Expose.Params
+    alias Ectomancer.SchemaIntrospection
 
     # Action configurations for data-driven generation
     @action_configs %{

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -122,6 +122,8 @@ if Code.ensure_loaded?(Ecto) do
     """
 
     alias Ectomancer.SchemaIntrospection
+    alias Ectomancer.Expose.Params
+    alias Ectomancer.Expose.Handlers
 
     # Action configurations for data-driven generation
     @action_configs %{
@@ -553,15 +555,14 @@ if Code.ensure_loaded?(Ecto) do
 
     defp generate_tool(action, config, tool_name) do
       description = build_description(action, config.resource_name, config.namespace)
-      params = generate_params(action, config)
+      params = Params.generate_params(action, config)
       auth_block = generate_authorization_block(action, config)
 
-      base_handler = select_handler(action, config)
+      base_handler = Handlers.select(action, config)
 
       handler =
         if config.field_authorize do
-          field_auth_fn = config.field_authorize
-          wrap_with_field_auth(base_handler, field_auth_fn)
+          Handlers.wrap_with_field_auth(base_handler, config.field_authorize)
         else
           base_handler
         end
@@ -576,204 +577,7 @@ if Code.ensure_loaded?(Ecto) do
       end
     end
 
-    defp select_handler(action, config) do
-      repo_module = config.repo
-      preload = config.preload
-
-      cond do
-        action == :upsert ->
-          generate_upsert_handler(repo_module, config)
-
-        action in [:batch_create, :batch_update, :batch_destroy] ->
-          generate_batch_handler(repo_module, config.schema, action, config.batch_size)
-
-        list_action?(action) ->
-          select_preload_handler(repo_module, preload, config, action)
-
-        true ->
-          generate_simple_handler(repo_module, preload, false, config.schema, action)
-      end
-    end
-
-    defp list_action?(action), do: action in [:list, :get]
-
-    defp select_preload_handler(repo_module, preload, config, action) do
-      has_preload = preload != []
-      has_preloadable = config.preloadable != false
-
-      cond do
-        has_preloadable and config.preloadable == :all ->
-          generate_handler_with_all_preloadable(
-            repo_module,
-            preload,
-            has_preload,
-            config.introspection,
-            config.schema,
-            action
-          )
-
-        has_preloadable and is_list(config.preloadable) ->
-          generate_handler_with_specific_preloadable(
-            repo_module,
-            preload,
-            has_preload,
-            config.preloadable,
-            config.schema,
-            action
-          )
-
-        true ->
-          generate_simple_handler(repo_module, preload, has_preload, config.schema, action)
-      end
-    end
-
-    defp generate_simple_handler(repo_module, preload, has_preload, schema, action) do
-      preload_expr =
-        if has_preload do
-          quote do: opts = Keyword.put(opts, :preload, unquote(preload))
-        else
-          quote do: :ok
-        end
-
-      repo_expr =
-        if repo_module do
-          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
-        else
-          quote do: :ok
-        end
-
-      quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope]
-          unquote(preload_expr)
-          unquote(repo_expr)
-          apply(Ectomancer.Repo, unquote(action), [unquote(schema), params, opts])
-        end
-      end
-    end
-
-    defp generate_upsert_handler(repo_module, config) do
-      conflict_target = config.conflict_target
-      on_conflict = config.on_conflict
-
-      repo_expr =
-        if repo_module do
-          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
-        else
-          quote do: :ok
-        end
-
-      quote do
-        fn params, _actor, scope ->
-          opts = [
-            scope: scope,
-            conflict_target: unquote(conflict_target),
-            on_conflict: unquote(on_conflict)
-          ]
-
-          unquote(repo_expr)
-          Ectomancer.Repo.upsert(unquote(config.schema), params, opts)
-        end
-      end
-    end
-
-    defp generate_batch_handler(repo_module, schema, action, batch_size) do
-      repo_expr =
-        if repo_module do
-          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
-        else
-          quote do: :ok
-        end
-
-      quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope, batch_size: unquote(batch_size)]
-          unquote(repo_expr)
-          apply(Ectomancer.Repo, unquote(action), [unquote(schema), params, opts])
-        end
-      end
-    end
-
-    defp generate_handler_with_all_preloadable(
-           repo_module,
-           preload,
-           has_preload,
-           introspection,
-           schema,
-           action
-         ) do
-      assoc_names = Enum.map(introspection.associations, &Atom.to_string(&1.field))
-
-      preload_expr =
-        if has_preload do
-          quote do: opts = Keyword.put(opts, :preload, unquote(preload))
-        else
-          quote do: :ok
-        end
-
-      repo_expr =
-        if repo_module do
-          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
-        else
-          quote do: :ok
-        end
-
-      quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope]
-          unquote(preload_expr)
-          {include, clean_params} = Map.pop(params, "include", nil)
-          opts = Ectomancer.Repo.validate_includes(include, unquote(assoc_names), opts)
-          unquote(repo_expr)
-          apply(Ectomancer.Repo, unquote(action), [unquote(schema), clean_params, opts])
-        end
-      end
-    end
-
-    defp generate_handler_with_specific_preloadable(
-           repo_module,
-           preload,
-           has_preload,
-           allowed,
-           schema,
-           action
-         ) do
-      preload_expr =
-        if has_preload do
-          quote do: opts = Keyword.put(opts, :preload, unquote(preload))
-        else
-          quote do: :ok
-        end
-
-      repo_expr =
-        if repo_module do
-          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
-        else
-          quote do: :ok
-        end
-
-      quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope]
-          unquote(preload_expr)
-          {include, clean_params} = Map.pop(params, "include", nil)
-          opts = Ectomancer.Repo.validate_includes(include, unquote(allowed), opts)
-          unquote(repo_expr)
-          apply(Ectomancer.Repo, unquote(action), [unquote(schema), clean_params, opts])
-        end
-      end
-    end
-
-    defp wrap_with_field_auth(base_handler, field_auth_fn) do
-      quote do
-        fn params, actor, scope ->
-          with {:ok, data} <- unquote(base_handler).(params, actor, scope) do
-            {:ok, Ectomancer.FieldAuth.filter_fields(data, actor, unquote(field_auth_fn))}
-          end
-        end
-      end
-    end
-
+    # Authorization block generation
     defp generate_authorization_block(action, config) do
       per_auth = config.authorization
       parent_auth = config.parent_authorization
@@ -872,235 +676,22 @@ if Code.ensure_loaded?(Ecto) do
     defp handler_to_raw_ast({:&, _, _} = capture_ast), do: capture_ast
     defp handler_to_raw_ast(handler) when is_function(handler), do: handler
 
-    @filter_suffixes %{
-      string: ~w(contains icontains not in),
-      number: ~w(gt gte lt lte not in),
-      datetime: ~w(gt gte lt lte not)
-    }
-
-    @number_types [:integer, :float, :decimal, :id]
-    @datetime_types [
-      :date,
-      :time,
-      :time_usec,
-      :naive_datetime,
-      :naive_datetime_usec,
-      :utc_datetime,
-      :utc_datetime_usec
-    ]
-
-    defp generate_params(:list, config) do
-      base_params = build_list_base_params(config.exposed_fields, config.introspection.types)
-
-      suffix_params =
-        build_list_filter_params(config.filterable_fields, config.introspection.types)
-
-      meta_params =
-        if config.soft_delete do
-          quote do
-            param(:order_by, :string)
-            param(:order_dir, :string)
-            param(:limit, :integer)
-            param(:offset, :integer)
-            param(:include_deleted, :boolean)
-            unquote(include_param(config.preloadable))
-          end
-        else
-          quote do
-            param(:order_by, :string)
-            param(:order_dir, :string)
-            param(:limit, :integer)
-            param(:offset, :integer)
-            unquote(include_param(config.preloadable))
-          end
-        end
-
-      all_params = base_params ++ suffix_params
-
-      case all_params do
-        [] ->
-          meta_params
-
-        _ ->
-          {:__block__, [], all_params ++ elem(meta_params, 2)}
-      end
-    end
-
-    defp generate_params(:get, config) do
-      # Get action requires the primary key
-      pk_field = hd(config.introspection.primary_key)
-      pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
-
-      if config.soft_delete do
-        quote do
-          param(unquote(pk_field), unquote(pk_type), required: true)
-          param(:include_deleted, :boolean)
-          unquote(include_param(config.preloadable))
-        end
-      else
-        quote do
-          param(unquote(pk_field), unquote(pk_type), required: true)
-          unquote(include_param(config.preloadable))
-        end
-      end
-    end
-
-    defp generate_params(:create, config) do
-      # Create action requires all writable fields
-      build_param_block(config.writable_fields, config.introspection.types)
-    end
-
-    defp generate_params(:update, config) do
-      # Update action requires primary key + writable fields
-      pk_field = hd(config.introspection.primary_key)
-      pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
-
-      writable_params = build_param_block(config.writable_fields, config.introspection.types)
-
-      quote do
-        param(unquote(pk_field), unquote(pk_type), required: true)
-        unquote(writable_params)
-      end
-    end
-
-    defp generate_params(:upsert, config) do
-      build_param_block(config.writable_fields, config.introspection.types)
-    end
-
-    defp generate_params(:destroy, config) do
-      # Destroy action requires the primary key
-      pk_field = hd(config.introspection.primary_key)
-      pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
-
-      quote do
-        param(unquote(pk_field), unquote(pk_type), required: true)
-      end
-    end
-
-    defp generate_params(:restore, config) do
-      # Restore action requires the primary key
-      pk_field = hd(config.introspection.primary_key)
-      pk_type = get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
-
-      quote do
-        param(unquote(pk_field), unquote(pk_type), required: true)
-      end
-    end
-
-    defp generate_params(:batch_create, _config) do
-      quote do
-        param(:records, {:array, :map},
-          required: true,
-          description: "Array of records to create"
-        )
-      end
-    end
-
-    defp generate_params(:batch_update, _config) do
-      quote do
-        param(:records, {:array, :map},
-          required: true,
-          description: "Array of records with id and fields to update"
-        )
-      end
-    end
-
-    defp generate_params(:batch_destroy, _config) do
-      quote do
-        param(:ids, :list,
-          required: true,
-          description: "Array of record IDs to delete"
-        )
-      end
-    end
-
-    defp build_list_base_params(fields, types) do
-      Enum.map(fields, fn field ->
-        type = Map.get(types, field)
-        build_single_param(field, type)
-      end)
-    end
-
-    defp build_list_filter_params(fields, types) do
-      Enum.flat_map(fields, fn field ->
-        type = Map.get(types, field)
-        build_suffix_params(field, type)
-      end)
-    end
-
-    defp build_single_param(field, type) do
-      param_type = get_ecto_type_for_param(type)
-
-      quote do
-        param(unquote(field), unquote(param_type))
-      end
-    end
-
-    defp build_suffix_params(field, type) do
-      suffixes = suffixes_for_type(type)
-
-      Enum.map(suffixes, fn suffix ->
-        suffixed_name = :"#{field}_#{suffix}"
-        param_type = suffix_param_type(suffix, type)
-
-        quote do
-          param(unquote(suffixed_name), unquote(param_type))
-        end
-      end)
-    end
-
-    defp suffixes_for_type(type) when type in @number_types, do: @filter_suffixes.number
-    defp suffixes_for_type(type) when type in @datetime_types, do: @filter_suffixes.datetime
-    defp suffixes_for_type(:string), do: @filter_suffixes.string
-    defp suffixes_for_type(:binary_id), do: ["not", "in"]
-    defp suffixes_for_type(Ecto.UUID), do: ["not", "in"]
-    defp suffixes_for_type(:boolean), do: ["not"]
-    defp suffixes_for_type(_), do: []
-
-    defp suffix_param_type("in", _type), do: :list
-    defp suffix_param_type(_suffix, type), do: get_ecto_type_for_param(type)
-
-    defp include_param(false), do: nil
-
-    defp include_param(_preloadable) do
-      quote do
-        param(:include, :list)
-      end
-    end
-
-    defp build_param_block(fields, types) do
-      fields
-      |> Enum.map(fn field ->
-        type = Map.get(types, field)
-        param_type = get_ecto_type_for_param(type)
-
-        quote do
-          param(unquote(field), unquote(param_type))
-        end
-      end)
-      |> case do
-        [] -> quote(do: :ok)
-        [single] -> single
-        multiple -> {:__block__, [], multiple}
-      end
-    end
-
-    # Map Ecto types to Peri/MCP types
-    defp get_ecto_type_for_param(:string), do: :string
-    defp get_ecto_type_for_param(:integer), do: :integer
-    defp get_ecto_type_for_param(:float), do: :float
-    defp get_ecto_type_for_param(:decimal), do: :float
-    defp get_ecto_type_for_param(:boolean), do: :boolean
-    defp get_ecto_type_for_param(:date), do: :string
-    defp get_ecto_type_for_param(:time), do: :string
-    defp get_ecto_type_for_param(:naive_datetime), do: :string
-    defp get_ecto_type_for_param(:utc_datetime), do: :string
-    defp get_ecto_type_for_param(:binary_id), do: :string
-    defp get_ecto_type_for_param(:id), do: :integer
-    defp get_ecto_type_for_param(Ecto.UUID), do: :string
-    defp get_ecto_type_for_param({:array, _}), do: :list
-    defp get_ecto_type_for_param(:map), do: :map
-    defp get_ecto_type_for_param(_), do: :string
+    @doc false
+    def get_ecto_type_for_param(:string), do: :string
+    def get_ecto_type_for_param(:integer), do: :integer
+    def get_ecto_type_for_param(:float), do: :float
+    def get_ecto_type_for_param(:decimal), do: :float
+    def get_ecto_type_for_param(:boolean), do: :boolean
+    def get_ecto_type_for_param(:date), do: :string
+    def get_ecto_type_for_param(:time), do: :string
+    def get_ecto_type_for_param(:naive_datetime), do: :string
+    def get_ecto_type_for_param(:utc_datetime), do: :string
+    def get_ecto_type_for_param(:binary_id), do: :string
+    def get_ecto_type_for_param(:id), do: :integer
+    def get_ecto_type_for_param(Ecto.UUID), do: :string
+    def get_ecto_type_for_param({:array, _}), do: :list
+    def get_ecto_type_for_param(:map), do: :map
+    def get_ecto_type_for_param(_), do: :string
 
     # Tool name building - data-driven approach
 

--- a/lib/ectomancer/expose/handlers.ex
+++ b/lib/ectomancer/expose/handlers.ex
@@ -1,0 +1,208 @@
+if Code.ensure_loaded?(Ecto) do
+  defmodule Ectomancer.Expose.Handlers do
+    @moduledoc false
+
+    @doc false
+    def select(action, config) do
+      repo_module = config.repo
+      preload = config.preload
+
+      cond do
+        action == :upsert ->
+          generate_upsert_handler(repo_module, config)
+
+        action in [:batch_create, :batch_update, :batch_destroy] ->
+          generate_batch_handler(repo_module, config.schema, action, config.batch_size)
+
+        list_action?(action) ->
+          select_preload_handler(repo_module, preload, config, action)
+
+        true ->
+          generate_simple_handler(repo_module, preload, false, config.schema, action)
+      end
+    end
+
+    defp list_action?(action), do: action in [:list, :get]
+
+    defp select_preload_handler(repo_module, preload, config, action) do
+      has_preload = preload != []
+      has_preloadable = config.preloadable != false
+
+      cond do
+        has_preloadable and config.preloadable == :all ->
+          generate_handler_with_all_preloadable(
+            repo_module,
+            preload,
+            has_preload,
+            config.introspection,
+            config.schema,
+            action
+          )
+
+        has_preloadable and is_list(config.preloadable) ->
+          generate_handler_with_specific_preloadable(
+            repo_module,
+            preload,
+            has_preload,
+            config.preloadable,
+            config.schema,
+            action
+          )
+
+        true ->
+          generate_simple_handler(repo_module, preload, has_preload, config.schema, action)
+      end
+    end
+
+    defp generate_simple_handler(repo_module, preload, has_preload, schema, action) do
+      preload_expr =
+        if has_preload do
+          quote do: opts = Keyword.put(opts, :preload, unquote(preload))
+        else
+          quote do: :ok
+        end
+
+      repo_expr =
+        if repo_module do
+          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
+        else
+          quote do: :ok
+        end
+
+      quote do
+        fn params, _actor, scope ->
+          opts = [scope: scope]
+          unquote(preload_expr)
+          unquote(repo_expr)
+          apply(Ectomancer.Repo, unquote(action), [unquote(schema), params, opts])
+        end
+      end
+    end
+
+    defp generate_upsert_handler(repo_module, config) do
+      conflict_target = config.conflict_target
+      on_conflict = config.on_conflict
+
+      repo_expr =
+        if repo_module do
+          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
+        else
+          quote do: :ok
+        end
+
+      quote do
+        fn params, _actor, scope ->
+          opts = [
+            scope: scope,
+            conflict_target: unquote(conflict_target),
+            on_conflict: unquote(on_conflict)
+          ]
+
+          unquote(repo_expr)
+          Ectomancer.Repo.upsert(unquote(config.schema), params, opts)
+        end
+      end
+    end
+
+    defp generate_batch_handler(repo_module, schema, action, batch_size) do
+      repo_expr =
+        if repo_module do
+          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
+        else
+          quote do: :ok
+        end
+
+      quote do
+        fn params, _actor, scope ->
+          opts = [scope: scope, batch_size: unquote(batch_size)]
+          unquote(repo_expr)
+          apply(Ectomancer.Repo, unquote(action), [unquote(schema), params, opts])
+        end
+      end
+    end
+
+    defp generate_handler_with_all_preloadable(
+           repo_module,
+           preload,
+           has_preload,
+           introspection,
+           schema,
+           action
+         ) do
+      assoc_names = Enum.map(introspection.associations, &Atom.to_string(&1.field))
+
+      preload_expr =
+        if has_preload do
+          quote do: opts = Keyword.put(opts, :preload, unquote(preload))
+        else
+          quote do: :ok
+        end
+
+      repo_expr =
+        if repo_module do
+          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
+        else
+          quote do: :ok
+        end
+
+      quote do
+        fn params, _actor, scope ->
+          opts = [scope: scope]
+          unquote(preload_expr)
+          {include, clean_params} = Map.pop(params, "include", nil)
+          opts = Ectomancer.Repo.validate_includes(include, unquote(assoc_names), opts)
+          unquote(repo_expr)
+          apply(Ectomancer.Repo, unquote(action), [unquote(schema), clean_params, opts])
+        end
+      end
+    end
+
+    defp generate_handler_with_specific_preloadable(
+           repo_module,
+           preload,
+           has_preload,
+           allowed,
+           schema,
+           action
+         ) do
+      preload_expr =
+        if has_preload do
+          quote do: opts = Keyword.put(opts, :preload, unquote(preload))
+        else
+          quote do: :ok
+        end
+
+      repo_expr =
+        if repo_module do
+          quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
+        else
+          quote do: :ok
+        end
+
+      quote do
+        fn params, _actor, scope ->
+          opts = [scope: scope]
+          unquote(preload_expr)
+          {include, clean_params} = Map.pop(params, "include", nil)
+          opts = Ectomancer.Repo.validate_includes(include, unquote(allowed), opts)
+          unquote(repo_expr)
+          apply(Ectomancer.Repo, unquote(action), [unquote(schema), clean_params, opts])
+        end
+      end
+    end
+
+    def wrap_with_field_auth(base_handler, field_auth_fn) do
+      quote do
+        fn params, actor, scope ->
+          with {:ok, data} <- unquote(base_handler).(params, actor, scope) do
+            {:ok, Ectomancer.FieldAuth.filter_fields(data, actor, unquote(field_auth_fn))}
+          end
+        end
+      end
+    end
+  end
+else
+  defmodule Ectomancer.Expose.Handlers do
+    @moduledoc false
+  end
+end

--- a/lib/ectomancer/expose/params.ex
+++ b/lib/ectomancer/expose/params.ex
@@ -63,7 +63,9 @@ if Code.ensure_loaded?(Ecto) do
 
     def generate_params(:get, config) do
       pk_field = hd(config.introspection.primary_key)
-      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      pk_type =
+        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       if config.soft_delete do
         quote do
@@ -85,7 +87,9 @@ if Code.ensure_loaded?(Ecto) do
 
     def generate_params(:update, config) do
       pk_field = hd(config.introspection.primary_key)
-      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      pk_type =
+        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       writable_params = build_param_block(config.writable_fields, config.introspection.types)
 
@@ -101,7 +105,9 @@ if Code.ensure_loaded?(Ecto) do
 
     def generate_params(:destroy, config) do
       pk_field = hd(config.introspection.primary_key)
-      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      pk_type =
+        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       quote do
         param(unquote(pk_field), unquote(pk_type), required: true)
@@ -110,7 +116,9 @@ if Code.ensure_loaded?(Ecto) do
 
     def generate_params(:restore, config) do
       pk_field = hd(config.introspection.primary_key)
-      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      pk_type =
+        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       quote do
         param(unquote(pk_field), unquote(pk_type), required: true)

--- a/lib/ectomancer/expose/params.ex
+++ b/lib/ectomancer/expose/params.ex
@@ -67,7 +67,7 @@ if Code.ensure_loaded?(Ecto) do
       pk_field = hd(config.introspection.primary_key)
 
       pk_type =
-        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+        Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       if config.soft_delete do
         quote do
@@ -91,7 +91,7 @@ if Code.ensure_loaded?(Ecto) do
       pk_field = hd(config.introspection.primary_key)
 
       pk_type =
-        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+        Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       writable_params = build_param_block(config.writable_fields, config.introspection.types)
 
@@ -109,7 +109,7 @@ if Code.ensure_loaded?(Ecto) do
       pk_field = hd(config.introspection.primary_key)
 
       pk_type =
-        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+        Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       quote do
         param(unquote(pk_field), unquote(pk_type), required: true)
@@ -120,7 +120,7 @@ if Code.ensure_loaded?(Ecto) do
       pk_field = hd(config.introspection.primary_key)
 
       pk_type =
-        Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+        Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
 
       quote do
         param(unquote(pk_field), unquote(pk_type), required: true)
@@ -169,7 +169,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp build_single_param(field, type) do
-      param_type = Ectomancer.Expose.get_ecto_type_for_param(type)
+      param_type = Expose.get_ecto_type_for_param(type)
 
       quote do
         param(unquote(field), unquote(param_type))
@@ -198,7 +198,7 @@ if Code.ensure_loaded?(Ecto) do
     defp suffixes_for_type(_), do: []
 
     defp suffix_param_type("in", _type), do: :list
-    defp suffix_param_type(_suffix, type), do: Ectomancer.Expose.get_ecto_type_for_param(type)
+    defp suffix_param_type(_suffix, type), do: Expose.get_ecto_type_for_param(type)
 
     defp include_param(false), do: nil
 
@@ -212,7 +212,7 @@ if Code.ensure_loaded?(Ecto) do
       fields
       |> Enum.map(fn field ->
         type = Map.get(types, field)
-        param_type = Ectomancer.Expose.get_ecto_type_for_param(type)
+        param_type = Expose.get_ecto_type_for_param(type)
 
         quote do
           param(unquote(field), unquote(param_type))

--- a/lib/ectomancer/expose/params.ex
+++ b/lib/ectomancer/expose/params.ex
@@ -2,6 +2,8 @@ if Code.ensure_loaded?(Ecto) do
   defmodule Ectomancer.Expose.Params do
     @moduledoc false
 
+    alias Ectomancer.Expose
+
     @filter_suffixes %{
       string: ~w(contains icontains not in),
       number: ~w(gt gte lt lte not in),
@@ -21,7 +23,7 @@ if Code.ensure_loaded?(Ecto) do
 
     @doc false
     def generate(action, config) do
-      Ectomancer.Expose.Params.generate_params(action, config)
+      generate_params(action, config)
     end
 
     def generate_params(:list, config) do

--- a/lib/ectomancer/expose/params.ex
+++ b/lib/ectomancer/expose/params.ex
@@ -1,0 +1,222 @@
+if Code.ensure_loaded?(Ecto) do
+  defmodule Ectomancer.Expose.Params do
+    @moduledoc false
+
+    @filter_suffixes %{
+      string: ~w(contains icontains not in),
+      number: ~w(gt gte lt lte not in),
+      datetime: ~w(gt gte lt lte not)
+    }
+
+    @number_types [:integer, :float, :decimal, :id]
+    @datetime_types [
+      :date,
+      :time,
+      :time_usec,
+      :naive_datetime,
+      :naive_datetime_usec,
+      :utc_datetime,
+      :utc_datetime_usec
+    ]
+
+    @doc false
+    def generate(action, config) do
+      Ectomancer.Expose.Params.generate_params(action, config)
+    end
+
+    def generate_params(:list, config) do
+      base_params = build_list_base_params(config.exposed_fields, config.introspection.types)
+
+      suffix_params =
+        build_list_filter_params(config.filterable_fields, config.introspection.types)
+
+      meta_params =
+        if config.soft_delete do
+          quote do
+            param(:order_by, :string)
+            param(:order_dir, :string)
+            param(:limit, :integer)
+            param(:offset, :integer)
+            param(:include_deleted, :boolean)
+            unquote(include_param(config.preloadable))
+          end
+        else
+          quote do
+            param(:order_by, :string)
+            param(:order_dir, :string)
+            param(:limit, :integer)
+            param(:offset, :integer)
+            unquote(include_param(config.preloadable))
+          end
+        end
+
+      all_params = base_params ++ suffix_params
+
+      case all_params do
+        [] ->
+          meta_params
+
+        _ ->
+          {:__block__, [], all_params ++ elem(meta_params, 2)}
+      end
+    end
+
+    def generate_params(:get, config) do
+      pk_field = hd(config.introspection.primary_key)
+      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      if config.soft_delete do
+        quote do
+          param(unquote(pk_field), unquote(pk_type), required: true)
+          param(:include_deleted, :boolean)
+          unquote(include_param(config.preloadable))
+        end
+      else
+        quote do
+          param(unquote(pk_field), unquote(pk_type), required: true)
+          unquote(include_param(config.preloadable))
+        end
+      end
+    end
+
+    def generate_params(:create, config) do
+      build_param_block(config.writable_fields, config.introspection.types)
+    end
+
+    def generate_params(:update, config) do
+      pk_field = hd(config.introspection.primary_key)
+      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      writable_params = build_param_block(config.writable_fields, config.introspection.types)
+
+      quote do
+        param(unquote(pk_field), unquote(pk_type), required: true)
+        unquote(writable_params)
+      end
+    end
+
+    def generate_params(:upsert, config) do
+      build_param_block(config.writable_fields, config.introspection.types)
+    end
+
+    def generate_params(:destroy, config) do
+      pk_field = hd(config.introspection.primary_key)
+      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      quote do
+        param(unquote(pk_field), unquote(pk_type), required: true)
+      end
+    end
+
+    def generate_params(:restore, config) do
+      pk_field = hd(config.introspection.primary_key)
+      pk_type = Ectomancer.Expose.get_ecto_type_for_param(Map.get(config.introspection.types, pk_field))
+
+      quote do
+        param(unquote(pk_field), unquote(pk_type), required: true)
+      end
+    end
+
+    def generate_params(:batch_create, _config) do
+      quote do
+        param(:records, {:array, :map},
+          required: true,
+          description: "Array of records to create"
+        )
+      end
+    end
+
+    def generate_params(:batch_update, _config) do
+      quote do
+        param(:records, {:array, :map},
+          required: true,
+          description: "Array of records with id and fields to update"
+        )
+      end
+    end
+
+    def generate_params(:batch_destroy, _config) do
+      quote do
+        param(:ids, :list,
+          required: true,
+          description: "Array of record IDs to delete"
+        )
+      end
+    end
+
+    defp build_list_base_params(fields, types) do
+      Enum.map(fields, fn field ->
+        type = Map.get(types, field)
+        build_single_param(field, type)
+      end)
+    end
+
+    defp build_list_filter_params(fields, types) do
+      Enum.flat_map(fields, fn field ->
+        type = Map.get(types, field)
+        build_suffix_params(field, type)
+      end)
+    end
+
+    defp build_single_param(field, type) do
+      param_type = Ectomancer.Expose.get_ecto_type_for_param(type)
+
+      quote do
+        param(unquote(field), unquote(param_type))
+      end
+    end
+
+    defp build_suffix_params(field, type) do
+      suffixes = suffixes_for_type(type)
+
+      Enum.map(suffixes, fn suffix ->
+        suffixed_name = :"#{field}_#{suffix}"
+        param_type = suffix_param_type(suffix, type)
+
+        quote do
+          param(unquote(suffixed_name), unquote(param_type))
+        end
+      end)
+    end
+
+    defp suffixes_for_type(type) when type in @number_types, do: @filter_suffixes.number
+    defp suffixes_for_type(type) when type in @datetime_types, do: @filter_suffixes.datetime
+    defp suffixes_for_type(:string), do: @filter_suffixes.string
+    defp suffixes_for_type(:binary_id), do: ["not", "in"]
+    defp suffixes_for_type(Ecto.UUID), do: ["not", "in"]
+    defp suffixes_for_type(:boolean), do: ["not"]
+    defp suffixes_for_type(_), do: []
+
+    defp suffix_param_type("in", _type), do: :list
+    defp suffix_param_type(_suffix, type), do: Ectomancer.Expose.get_ecto_type_for_param(type)
+
+    defp include_param(false), do: nil
+
+    defp include_param(_preloadable) do
+      quote do
+        param(:include, :list)
+      end
+    end
+
+    def build_param_block(fields, types) do
+      fields
+      |> Enum.map(fn field ->
+        type = Map.get(types, field)
+        param_type = Ectomancer.Expose.get_ecto_type_for_param(type)
+
+        quote do
+          param(unquote(field), unquote(param_type))
+        end
+      end)
+      |> case do
+        [] -> quote(do: :ok)
+        [single] -> single
+        multiple -> {:__block__, [], multiple}
+      end
+    end
+  end
+else
+  defmodule Ectomancer.Expose.Params do
+    @moduledoc false
+  end
+end

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -127,7 +127,7 @@ if Code.ensure_loaded?(Oban) do
           unquote(oban_authorize_call(auth_handler))
 
           handle(fn _params, _actor ->
-            Ectomancer.ObanBridge.list_queues()
+            Ectomancer.ObanBridge.Queries.list_queues()
           end)
         end
       end
@@ -145,7 +145,7 @@ if Code.ensure_loaded?(Oban) do
 
           handle(fn params, _actor ->
             queue_name = params["queue_name"] || params[:queue_name]
-            Ectomancer.ObanBridge.get_queue_depth(queue_name)
+            Ectomancer.ObanBridge.Queries.get_queue_depth(queue_name)
           end)
         end
       end
@@ -175,7 +175,7 @@ if Code.ensure_loaded?(Oban) do
               |> Enum.reject(fn {_k, v} -> is_nil(v) end)
               |> Enum.into(%{})
 
-            Ectomancer.ObanBridge.list_stuck_jobs(filters)
+            Ectomancer.ObanBridge.Queries.list_stuck_jobs(filters)
           end)
         end
       end
@@ -193,7 +193,7 @@ if Code.ensure_loaded?(Oban) do
 
           handle(fn params, _actor ->
             job_id = params["job_id"] || params[:job_id]
-            Ectomancer.ObanBridge.retry_job(job_id)
+            Ectomancer.ObanBridge.Queries.retry_job(job_id)
           end)
         end
       end
@@ -211,249 +211,46 @@ if Code.ensure_loaded?(Oban) do
 
           handle(fn params, _actor ->
             job_id = params["job_id"] || params[:job_id]
-            Ectomancer.ObanBridge.cancel_job(job_id)
+            Ectomancer.ObanBridge.Queries.cancel_job(job_id)
           end)
         end
       end
     end
 
-    # Public API implementations
-
     @doc false
-    def list_queues do
-      import Ecto.Query
-
-      # Check repo is configured before attempting query
-      _ = repo()
-
-      try do
-        queues =
-          Oban.Job
-          |> select(
-            [j],
-            {j.queue, fragment("COUNT(*)"),
-             fragment("SUM(CASE WHEN state = 'executing' THEN 1 ELSE 0 END)"),
-             fragment("SUM(CASE WHEN state = 'available' THEN 1 ELSE 0 END)"),
-             fragment("SUM(CASE WHEN state = 'retryable' THEN 1 ELSE 0 END)"),
-             fragment("SUM(CASE WHEN state = 'discarded' THEN 1 ELSE 0 END)")}
-          )
-          |> group_by([j], j.queue)
-          |> order_by([j], j.queue)
-          |> repo_all()
-
-        formatted_queues =
-          Enum.map(queues, fn {queue, total, executing, available, retryable, discarded} ->
-            %{
-              queue: queue,
-              total: total || 0,
-              executing: executing || 0,
-              available: available || 0,
-              retryable: retryable || 0,
-              discarded: discarded || 0
-            }
-          end)
-
-        {:ok, %{queues: formatted_queues}}
-      rescue
-        e ->
-          {:error, "Failed to list queues: #{Exception.message(e)}"}
-      end
-    end
-
+    defdelegate list_queues(), to: Ectomancer.ObanBridge.Queries
     @doc false
-    def get_queue_depth(queue_name) when is_binary(queue_name) do
-      import Ecto.Query
-
-      # Check repo is configured before attempting query
-      _ = repo()
-
-      try do
-        counts =
-          Oban.Job
-          |> where([j], j.queue == ^queue_name)
-          |> select([j], {
-            fragment("COUNT(*)"),
-            fragment("SUM(CASE WHEN state = 'executing' THEN 1 ELSE 0 END)"),
-            fragment("SUM(CASE WHEN state = 'available' THEN 1 ELSE 0 END)"),
-            fragment("SUM(CASE WHEN state = 'retryable' THEN 1 ELSE 0 END)"),
-            fragment("SUM(CASE WHEN state = 'discarded' THEN 1 ELSE 0 END)")
-          })
-          |> repo_one()
-
-        case counts do
-          nil ->
-            {:ok,
-             %{
-               queue: queue_name,
-               total: 0,
-               executing: 0,
-               available: 0,
-               retryable: 0,
-               discarded: 0
-             }}
-
-          {total, executing, available, retryable, discarded} ->
-            {:ok,
-             %{
-               queue: queue_name,
-               total: total || 0,
-               executing: executing || 0,
-               available: available || 0,
-               retryable: retryable || 0,
-               discarded: discarded || 0
-             }}
-        end
-      rescue
-        e ->
-          {:error, "Failed to get queue depth: #{Exception.message(e)}"}
-      end
-    end
-
-    def get_queue_depth(_), do: {:error, "queue_name must be a string"}
-
+    def get_queue_depth(queue_name) when is_binary(queue_name),
+      do: Ectomancer.ObanBridge.Queries.get_queue_depth(queue_name)
     @doc false
-    def list_stuck_jobs(filters \\ %{}) do
-      import Ecto.Query
-
-      # Check repo is configured before attempting query
-      _ = repo()
-
-      try do
-        query =
-          Oban.Job
-          |> where([j], j.state == "executing")
-
-        # Apply optional filters
-        query =
-          Enum.reduce(filters, query, fn
-            {:queue, queue}, q ->
-              where(q, [j], j.queue == ^queue)
-
-            {:worker, worker}, q ->
-              where(q, [j], j.worker == ^worker)
-
-            {:min_age_minutes, minutes}, q ->
-              cutoff = DateTime.utc_now() |> DateTime.add(-minutes, :minute)
-              where(q, [j], j.attempted_at < ^cutoff)
-
-            _, q ->
-              q
-          end)
-
-        query =
-          query
-          |> order_by([j], desc: j.attempted_at)
-          |> limit(^Map.get(filters, :limit, 100))
-
-        jobs = repo_all(query)
-
-        formatted_jobs =
-          Enum.map(jobs, fn job ->
-            %{
-              id: job.id,
-              queue: job.queue,
-              worker: job.worker,
-              args: job.args,
-              state: job.state,
-              attempt: job.attempt,
-              max_attempts: job.max_attempts,
-              attempted_at: job.attempted_at,
-              inserted_at: job.inserted_at,
-              errors: job.errors
-            }
-          end)
-
-        {:ok, %{jobs: formatted_jobs, count: length(formatted_jobs)}}
-      rescue
-        e ->
-          {:error, "Failed to list stuck jobs: #{Exception.message(e)}"}
-      end
-    end
-
+    def get_queue_depth(other),
+      do: Ectomancer.ObanBridge.Queries.get_queue_depth(other)
     @doc false
-    def retry_job(job_id) when is_integer(job_id) do
-      import Ecto.Query
-
-      # Check repo is configured before attempting query
-      _ = repo()
-
-      try do
-        # Update the job to be available again
-        {count, _} =
-          Oban.Job
-          |> where([j], j.id == ^job_id)
-          |> where([j], j.state in ["retryable", "discarded"])
-          |> repo_update_all(set: [state: "available", scheduled_at: DateTime.utc_now()])
-
-        if count > 0 do
-          {:ok, %{message: "Job #{job_id} scheduled for retry", job_id: job_id}}
-        else
-          {:error, "Job #{job_id} not found or not in retryable/discarded state"}
-        end
-      rescue
-        e ->
-          {:error, "Failed to retry job: #{Exception.message(e)}"}
-      end
-    end
-
-    def retry_job(_), do: {:error, "job_id must be an integer"}
-
+    def list_stuck_jobs(), do: Ectomancer.ObanBridge.Queries.list_stuck_jobs()
     @doc false
-    def cancel_job(job_id) when is_integer(job_id) do
-      import Ecto.Query
-
-      # Check repo is configured before attempting query
-      _ = repo()
-
-      try do
-        # Cancel the job if it's not already completed
-        {count, _} =
-          Oban.Job
-          |> where([j], j.id == ^job_id)
-          |> where([j], j.state != "completed")
-          |> repo_delete_all()
-
-        if count > 0 do
-          {:ok, %{message: "Job #{job_id} cancelled", job_id: job_id}}
-        else
-          {:error, "Job #{job_id} not found or already completed"}
-        end
-      rescue
-        e ->
-          {:error, "Failed to cancel job: #{Exception.message(e)}"}
-      end
-    end
-
-    def cancel_job(_), do: {:error, "job_id must be an integer"}
-
-    # Helper functions to work with configured repo
-
+    defdelegate list_stuck_jobs(filters), to: Ectomancer.ObanBridge.Queries
     @doc false
-    def repo do
-      Application.get_env(:ectomancer, :repo) ||
-        raise ArgumentError,
-              "Ectomancer repo not configured. Set config :ectomancer, :repo, YourApp.Repo"
-    end
-
+    def retry_job(job_id) when is_integer(job_id),
+      do: Ectomancer.ObanBridge.Queries.retry_job(job_id)
     @doc false
-    def repo_all(query) do
-      repo().all(query)
-    end
-
+    def retry_job(other),
+      do: Ectomancer.ObanBridge.Queries.retry_job(other)
     @doc false
-    def repo_one(query) do
-      repo().one(query)
-    end
-
+    def cancel_job(job_id) when is_integer(job_id),
+      do: Ectomancer.ObanBridge.Queries.cancel_job(job_id)
     @doc false
-    def repo_update_all(query, opts) do
-      repo().update_all(query, opts)
-    end
-
+    def cancel_job(other),
+      do: Ectomancer.ObanBridge.Queries.cancel_job(other)
     @doc false
-    def repo_delete_all(query) do
-      repo().delete_all(query)
-    end
+    defdelegate repo(), to: Ectomancer.ObanBridge.Queries
+    @doc false
+    defdelegate repo_all(query), to: Ectomancer.ObanBridge.Queries
+    @doc false
+    defdelegate repo_one(query), to: Ectomancer.ObanBridge.Queries
+    @doc false
+    defdelegate repo_update_all(query, opts), to: Ectomancer.ObanBridge.Queries
+    @doc false
+    defdelegate repo_delete_all(query), to: Ectomancer.ObanBridge.Queries
   end
 else
   defmodule Ectomancer.ObanBridge do

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -242,15 +242,7 @@ if Code.ensure_loaded?(Oban) do
     def cancel_job(other),
       do: Ectomancer.ObanBridge.Queries.cancel_job(other)
     @doc false
-    defdelegate repo(), to: Ectomancer.ObanBridge.Queries
-    @doc false
-    defdelegate repo_all(query), to: Ectomancer.ObanBridge.Queries
-    @doc false
-    defdelegate repo_one(query), to: Ectomancer.ObanBridge.Queries
-    @doc false
-    defdelegate repo_update_all(query, opts), to: Ectomancer.ObanBridge.Queries
-    @doc false
-    defdelegate repo_delete_all(query), to: Ectomancer.ObanBridge.Queries
+    def repo, do: Ectomancer.ObanBridge.Queries.repo()
   end
 else
   defmodule Ectomancer.ObanBridge do

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -72,9 +72,9 @@ if Code.ensure_loaded?(Oban) do
 
         auth_handler =
           if Keyword.has_key?(opts, :authorize) do
-            Ectomancer.Expose.parse_auth_config(opts[:authorize])
+            Ectomancer.Authorization.parse_handler_for_global(opts[:authorize])
           else
-            Ectomancer.Expose.parse_auth_config(global_auth_raw)
+            Ectomancer.Authorization.parse_handler_for_global(global_auth_raw)
           end
 
         generate_oban_tools(namespace, auth_handler)
@@ -111,30 +111,10 @@ if Code.ensure_loaded?(Oban) do
     end
 
     @doc false
-    def oban_authorize_call(nil), do: quote(do: authorize(:none))
+    def oban_authorize_call(nil), do: Ectomancer.Authorization.authorize_to_ast(nil)
 
-    def oban_authorize_call(module) when is_atom(module) do
-      quote do
-        authorize(with: unquote(module))
-      end
-    end
-
-    def oban_authorize_call(handler) when is_function(handler) do
-      quote do
-        authorize(unquote(handler))
-      end
-    end
-
-    def oban_authorize_call({:fn, _, _} = fn_ast) do
-      quote do
-        authorize(unquote(fn_ast))
-      end
-    end
-
-    def oban_authorize_call({:&, _, _} = capture_ast) do
-      quote do
-        authorize(unquote(capture_ast))
-      end
+    def oban_authorize_call(handler) do
+      Ectomancer.Authorization.authorize_to_ast(handler)
     end
 
     # Tool 1: list_oban_queues

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -49,6 +49,8 @@ if Code.ensure_loaded?(Oban) do
     authorization at the MCP module level.
     """
 
+    alias Ectomancer.ObanBridge.Queries
+
     @doc """
     Exposes Oban job management tools.
 
@@ -127,7 +129,7 @@ if Code.ensure_loaded?(Oban) do
           unquote(oban_authorize_call(auth_handler))
 
           handle(fn _params, _actor ->
-            Ectomancer.ObanBridge.Queries.list_queues()
+            Queries.list_queues()
           end)
         end
       end
@@ -145,7 +147,7 @@ if Code.ensure_loaded?(Oban) do
 
           handle(fn params, _actor ->
             queue_name = params["queue_name"] || params[:queue_name]
-            Ectomancer.ObanBridge.Queries.get_queue_depth(queue_name)
+            Queries.get_queue_depth(queue_name)
           end)
         end
       end
@@ -175,7 +177,7 @@ if Code.ensure_loaded?(Oban) do
               |> Enum.reject(fn {_k, v} -> is_nil(v) end)
               |> Enum.into(%{})
 
-            Ectomancer.ObanBridge.Queries.list_stuck_jobs(filters)
+            Queries.list_stuck_jobs(filters)
           end)
         end
       end
@@ -193,7 +195,7 @@ if Code.ensure_loaded?(Oban) do
 
           handle(fn params, _actor ->
             job_id = params["job_id"] || params[:job_id]
-            Ectomancer.ObanBridge.Queries.retry_job(job_id)
+            Queries.retry_job(job_id)
           end)
         end
       end
@@ -211,7 +213,7 @@ if Code.ensure_loaded?(Oban) do
 
           handle(fn params, _actor ->
             job_id = params["job_id"] || params[:job_id]
-            Ectomancer.ObanBridge.Queries.cancel_job(job_id)
+            Queries.cancel_job(job_id)
           end)
         end
       end
@@ -221,34 +223,34 @@ if Code.ensure_loaded?(Oban) do
     defdelegate list_queues(), to: Ectomancer.ObanBridge.Queries
     @doc false
     def get_queue_depth(queue_name) when is_binary(queue_name),
-      do: Ectomancer.ObanBridge.Queries.get_queue_depth(queue_name)
+      do: Queries.get_queue_depth(queue_name)
 
     @doc false
     def get_queue_depth(other),
-      do: Ectomancer.ObanBridge.Queries.get_queue_depth(other)
+      do: Queries.get_queue_depth(other)
 
     @doc false
-    def list_stuck_jobs(), do: Ectomancer.ObanBridge.Queries.list_stuck_jobs()
+    def list_stuck_jobs, do: Queries.list_stuck_jobs()
     @doc false
     defdelegate list_stuck_jobs(filters), to: Ectomancer.ObanBridge.Queries
     @doc false
     def retry_job(job_id) when is_integer(job_id),
-      do: Ectomancer.ObanBridge.Queries.retry_job(job_id)
+      do: Queries.retry_job(job_id)
 
     @doc false
     def retry_job(other),
-      do: Ectomancer.ObanBridge.Queries.retry_job(other)
+      do: Queries.retry_job(other)
 
     @doc false
     def cancel_job(job_id) when is_integer(job_id),
-      do: Ectomancer.ObanBridge.Queries.cancel_job(job_id)
+      do: Queries.cancel_job(job_id)
 
     @doc false
     def cancel_job(other),
-      do: Ectomancer.ObanBridge.Queries.cancel_job(other)
+      do: Queries.cancel_job(other)
 
     @doc false
-    def repo, do: Ectomancer.ObanBridge.Queries.repo()
+    def repo, do: Queries.repo()
   end
 else
   defmodule Ectomancer.ObanBridge do

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -222,9 +222,11 @@ if Code.ensure_loaded?(Oban) do
     @doc false
     def get_queue_depth(queue_name) when is_binary(queue_name),
       do: Ectomancer.ObanBridge.Queries.get_queue_depth(queue_name)
+
     @doc false
     def get_queue_depth(other),
       do: Ectomancer.ObanBridge.Queries.get_queue_depth(other)
+
     @doc false
     def list_stuck_jobs(), do: Ectomancer.ObanBridge.Queries.list_stuck_jobs()
     @doc false
@@ -232,15 +234,19 @@ if Code.ensure_loaded?(Oban) do
     @doc false
     def retry_job(job_id) when is_integer(job_id),
       do: Ectomancer.ObanBridge.Queries.retry_job(job_id)
+
     @doc false
     def retry_job(other),
       do: Ectomancer.ObanBridge.Queries.retry_job(other)
+
     @doc false
     def cancel_job(job_id) when is_integer(job_id),
       do: Ectomancer.ObanBridge.Queries.cancel_job(job_id)
+
     @doc false
     def cancel_job(other),
       do: Ectomancer.ObanBridge.Queries.cancel_job(other)
+
     @doc false
     def repo, do: Ectomancer.ObanBridge.Queries.repo()
   end

--- a/lib/ectomancer/oban_bridge/queries.ex
+++ b/lib/ectomancer/oban_bridge/queries.ex
@@ -1,0 +1,200 @@
+if Code.ensure_loaded?(Oban) do
+  defmodule Ectomancer.ObanBridge.Queries do
+    @moduledoc false
+
+    import Ecto.Query
+
+    def list_queues do
+      _ = repo()
+
+      try do
+        queues =
+          Oban.Job
+          |> select(
+            [j],
+            {j.queue, fragment("COUNT(*)"),
+             fragment("SUM(CASE WHEN state = 'executing' THEN 1 ELSE 0 END)"),
+             fragment("SUM(CASE WHEN state = 'available' THEN 1 ELSE 0 END)"),
+             fragment("SUM(CASE WHEN state = 'retryable' THEN 1 ELSE 0 END)"),
+             fragment("SUM(CASE WHEN state = 'discarded' THEN 1 ELSE 0 END)")}
+          )
+          |> group_by([j], j.queue)
+          |> order_by([j], j.queue)
+          |> repo_all()
+
+        formatted =
+          Enum.map(queues, fn {queue, total, executing, available, retryable, discarded} ->
+            %{
+              queue: queue,
+              total: total || 0,
+              executing: executing || 0,
+              available: available || 0,
+              retryable: retryable || 0,
+              discarded: discarded || 0
+            }
+          end)
+
+        {:ok, %{queues: formatted}}
+      rescue
+        e ->
+          {:error, "Failed to list queues: #{Exception.message(e)}"}
+      end
+    end
+
+    def get_queue_depth(queue_name) when is_binary(queue_name) do
+      _ = repo()
+
+      try do
+        counts =
+          Oban.Job
+          |> where([j], j.queue == ^queue_name)
+          |> select([j], {
+            fragment("COUNT(*)"),
+            fragment("SUM(CASE WHEN state = 'executing' THEN 1 ELSE 0 END)"),
+            fragment("SUM(CASE WHEN state = 'available' THEN 1 ELSE 0 END)"),
+            fragment("SUM(CASE WHEN state = 'retryable' THEN 1 ELSE 0 END)"),
+            fragment("SUM(CASE WHEN state = 'discarded' THEN 1 ELSE 0 END)")
+          })
+          |> repo_one()
+
+        case counts do
+          nil ->
+            {:ok,
+             %{
+               queue: queue_name,
+               total: 0,
+               executing: 0,
+               available: 0,
+               retryable: 0,
+               discarded: 0
+             }}
+
+          {total, executing, available, retryable, discarded} ->
+            {:ok,
+             %{
+               queue: queue_name,
+               total: total || 0,
+               executing: executing || 0,
+               available: available || 0,
+               retryable: retryable || 0,
+               discarded: discarded || 0
+             }}
+        end
+      rescue
+        e ->
+          {:error, "Failed to get queue depth: #{Exception.message(e)}"}
+      end
+    end
+
+    def get_queue_depth(_), do: {:error, "queue_name must be a string"}
+
+    def list_stuck_jobs(filters \\ %{}) do
+      _ = repo()
+
+      try do
+        query =
+          Oban.Job
+          |> where([j], j.state == "executing")
+
+        query =
+          Enum.reduce(filters, query, fn
+            {:queue, queue}, q -> where(q, [j], j.queue == ^queue)
+            {:worker, worker}, q -> where(q, [j], j.worker == ^worker)
+            {:min_age_minutes, minutes}, q ->
+              cutoff = DateTime.utc_now() |> DateTime.add(-minutes, :minute)
+              where(q, [j], j.attempted_at < ^cutoff)
+            _, q -> q
+          end)
+
+        query =
+          query
+          |> order_by([j], desc: j.attempted_at)
+          |> limit(^Map.get(filters, :limit, 100))
+
+        jobs = repo_all(query)
+
+        formatted =
+          Enum.map(jobs, fn job ->
+            %{
+              id: job.id,
+              queue: job.queue,
+              worker: job.worker,
+              args: job.args,
+              state: job.state,
+              attempt: job.attempt,
+              max_attempts: job.max_attempts,
+              attempted_at: job.attempted_at,
+              inserted_at: job.inserted_at,
+              errors: job.errors
+            }
+          end)
+
+        {:ok, %{jobs: formatted, count: length(formatted)}}
+      rescue
+        e ->
+          {:error, "Failed to list stuck jobs: #{Exception.message(e)}"}
+      end
+    end
+
+    def retry_job(job_id) when is_integer(job_id) do
+      _ = repo()
+
+      try do
+        {count, _} =
+          Oban.Job
+          |> where([j], j.id == ^job_id)
+          |> where([j], j.state in ["retryable", "discarded"])
+          |> repo_update_all(set: [state: "available", scheduled_at: DateTime.utc_now()])
+
+        if count > 0 do
+          {:ok, %{message: "Job #{job_id} scheduled for retry", job_id: job_id}}
+        else
+          {:error, "Job #{job_id} not found or not in retryable/discarded state"}
+        end
+      rescue
+        e ->
+          {:error, "Failed to retry job: #{Exception.message(e)}"}
+      end
+    end
+
+    def retry_job(_), do: {:error, "job_id must be an integer"}
+
+    def cancel_job(job_id) when is_integer(job_id) do
+      _ = repo()
+
+      try do
+        {count, _} =
+          Oban.Job
+          |> where([j], j.id == ^job_id)
+          |> where([j], j.state != "completed")
+          |> repo_delete_all()
+
+        if count > 0 do
+          {:ok, %{message: "Job #{job_id} cancelled", job_id: job_id}}
+        else
+          {:error, "Job #{job_id} not found or already completed"}
+        end
+      rescue
+        e ->
+          {:error, "Failed to cancel job: #{Exception.message(e)}"}
+      end
+    end
+
+    def cancel_job(_), do: {:error, "job_id must be an integer"}
+
+    def repo do
+      Application.get_env(:ectomancer, :repo) ||
+        raise ArgumentError,
+              "Ectomancer repo not configured. Set config :ectomancer, :repo, YourApp.Repo"
+    end
+
+    defp repo_all(query), do: repo().all(query)
+    defp repo_one(query), do: repo().one(query)
+    defp repo_update_all(query, opts), do: repo().update_all(query, opts)
+    defp repo_delete_all(query), do: repo().delete_all(query)
+  end
+else
+  defmodule Ectomancer.ObanBridge.Queries do
+    @moduledoc false
+  end
+end

--- a/lib/ectomancer/oban_bridge/queries.ex
+++ b/lib/ectomancer/oban_bridge/queries.ex
@@ -98,12 +98,18 @@ if Code.ensure_loaded?(Oban) do
 
         query =
           Enum.reduce(filters, query, fn
-            {:queue, queue}, q -> where(q, [j], j.queue == ^queue)
-            {:worker, worker}, q -> where(q, [j], j.worker == ^worker)
+            {:queue, queue}, q ->
+              where(q, [j], j.queue == ^queue)
+
+            {:worker, worker}, q ->
+              where(q, [j], j.worker == ^worker)
+
             {:min_age_minutes, minutes}, q ->
               cutoff = DateTime.utc_now() |> DateTime.add(-minutes, :minute)
               where(q, [j], j.attempted_at < ^cutoff)
-            _, q -> q
+
+            _, q ->
+              q
           end)
 
         query =

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -22,8 +22,8 @@ if Code.ensure_loaded?(Ecto) do
     module namespace.
     """
 
-    alias Ectomancer.SchemaIntrospection
     alias Ectomancer.Repo.Filtering
+    alias Ectomancer.SchemaIntrospection
 
     @doc """
     Gets the configured Repo module.

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -23,6 +23,7 @@ if Code.ensure_loaded?(Ecto) do
     """
 
     alias Ectomancer.SchemaIntrospection
+    alias Ectomancer.Repo.Filtering
 
     @doc """
     Gets the configured Repo module.
@@ -66,15 +67,15 @@ if Code.ensure_loaded?(Ecto) do
         try do
           with_repo(opts, fn repo ->
             introspection = SchemaIntrospection.analyze(schema_module)
-            {meta_params, filter_params} = extract_meta_params(params)
+            {meta_params, filter_params} = Filtering.extract_meta_params(params)
 
             query =
               schema_module
-              |> build_filter_query(filter_params, introspection.fields)
-              |> apply_scope(Keyword.get(opts, :scope))
-              |> apply_soft_delete_filter(schema_module, meta_params)
-              |> apply_ordering(meta_params, introspection.fields)
-              |> apply_pagination(meta_params, opts)
+              |> Filtering.build_filter_query(filter_params, introspection.fields)
+              |> Filtering.apply_scope(Keyword.get(opts, :scope))
+              |> Filtering.apply_soft_delete_filter(schema_module, meta_params)
+              |> Filtering.apply_ordering(meta_params, introspection.fields)
+              |> Filtering.apply_pagination(meta_params, opts)
 
             results = repo.all(query)
             {:ok, maybe_preload(repo, results, opts)}
@@ -153,14 +154,7 @@ if Code.ensure_loaded?(Ecto) do
           with_repo(opts, fn repo ->
             struct = struct(schema_module)
             attrs = normalize_params(params || %{}, schema_module)
-
-            changeset =
-              if function_exported?(schema_module, :changeset, 2) do
-                schema_module.changeset(struct, attrs)
-              else
-                writable = writable_fields(schema_module)
-                Ecto.Changeset.cast(struct, attrs, writable)
-              end
+            changeset = changeset_for(schema_module, struct, attrs, writable_fields(schema_module))
 
             case repo.insert(changeset) do
               {:ok, record} -> {:ok, record}
@@ -293,7 +287,7 @@ if Code.ensure_loaded?(Ecto) do
 
         query =
           query
-          |> apply_scope(Keyword.get(opts, :scope))
+          |> Filtering.apply_scope(Keyword.get(opts, :scope))
 
         case repo.one(query) do
           nil -> insert_for_upsert(repo, schema_module, attrs, :inserted)
@@ -332,24 +326,19 @@ if Code.ensure_loaded?(Ecto) do
       update_attrs =
         if is_nil(sd_field), do: update_attrs, else: Map.put(update_attrs, sd_field, nil)
 
-      changeset =
-        if function_exported?(schema_module, :changeset, 2) do
-          schema_module.changeset(existing, update_attrs)
+      writable =
+        schema_module
+        |> writable_fields()
+        |> Enum.reject(fn f -> f in pk_fields end)
+
+      writable =
+        if not is_nil(sd_field) and sd_field not in writable do
+          [sd_field | writable]
         else
-          writable =
-            schema_module
-            |> writable_fields()
-            |> Enum.reject(fn f -> f in pk_fields end)
-
-          writable =
-            if not is_nil(sd_field) and sd_field not in writable do
-              [sd_field | writable]
-            else
-              writable
-            end
-
-          Ecto.Changeset.cast(existing, update_attrs, writable)
+          writable
         end
+
+      changeset = changeset_for(schema_module, existing, update_attrs, writable)
 
       case repo.update(changeset) do
         {:ok, record} -> {:ok, {record, :updated}}
@@ -552,12 +541,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp build_create_changeset(schema_module, struct, attrs) do
-      if function_exported?(schema_module, :changeset, 2) do
-        schema_module.changeset(struct, attrs)
-      else
-        writable = writable_fields(schema_module)
-        Ecto.Changeset.cast(struct, attrs, writable)
-      end
+      changeset_for(schema_module, struct, attrs, writable_fields(schema_module))
     end
 
     defp perform_batch_destroy(repo, schema_module, raw_id, opts) do
@@ -571,7 +555,7 @@ if Code.ensure_loaded?(Ecto) do
       query =
         schema_module
         |> build_pk_query(pk_values)
-        |> apply_scope(scope)
+        |> Filtering.apply_scope(scope)
 
       case repo.one(query) do
         nil ->
@@ -615,7 +599,7 @@ if Code.ensure_loaded?(Ecto) do
       query =
         schema_module
         |> build_pk_query(pk_values)
-        |> apply_scope(scope)
+        |> Filtering.apply_scope(scope)
 
       case repo.one(query) do
         nil ->
@@ -638,16 +622,12 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp build_changeset(schema_module, record, update_attrs, pk_fields) do
-      if function_exported?(schema_module, :changeset, 2) do
-        schema_module.changeset(record, update_attrs)
-      else
-        writable =
-          schema_module
-          |> writable_fields()
-          |> Enum.reject(fn f -> f in pk_fields end)
+      writable =
+        schema_module
+        |> writable_fields()
+        |> Enum.reject(fn f -> f in pk_fields end)
 
-        Ecto.Changeset.cast(record, update_attrs, writable)
-      end
+      changeset_for(schema_module, record, update_attrs, writable)
     end
 
     defp run_batch(repo, _schema_module, items, _opts, operation) do
@@ -775,7 +755,7 @@ if Code.ensure_loaded?(Ecto) do
       query =
         schema_module
         |> build_pk_query(pk_values)
-        |> apply_scope(Keyword.get(opts, :scope))
+        |> Filtering.apply_scope(Keyword.get(opts, :scope))
 
       case repo.one(query) do
         nil -> {:error, :not_found}
@@ -790,19 +770,12 @@ if Code.ensure_loaded?(Ecto) do
         |> Enum.reject(fn {k, _v} -> k in pk_fields end)
         |> Enum.into(%{})
 
-      # Use the schema's changeset function if available, otherwise fallback to cast
-      changeset =
-        if function_exported?(schema_module, :changeset, 2) do
-          schema_module.changeset(record, update_attrs)
-        else
-          writable =
-            schema_module
-            |> writable_fields()
-            |> Enum.reject(fn f -> f in pk_fields end)
+      writable =
+        schema_module
+        |> writable_fields()
+        |> Enum.reject(fn f -> f in pk_fields end)
 
-          Ecto.Changeset.cast(record, update_attrs, writable)
-        end
-
+      changeset = changeset_for(schema_module, record, update_attrs, writable)
       repo.update(changeset)
     end
 
@@ -827,20 +800,11 @@ if Code.ensure_loaded?(Ecto) do
       repo.update(changeset)
     end
 
-    defp apply_soft_delete_filter(query, schema_module, meta_params) do
-      import Ecto.Query
-
-      sd_field = SchemaIntrospection.soft_delete_field(schema_module)
-
-      if sd_field && !Map.get(meta_params, "include_deleted", false) do
-        where(query, [r], is_nil(field(r, ^sd_field)))
-      else
-        query
-      end
-    end
-
-    defp apply_scope(query, nil), do: query
-    defp apply_scope(query, scope_fn) when is_function(scope_fn, 1), do: scope_fn.(query)
+    defdelegate extract_meta_params(params), to: Filtering
+    defdelegate parse_filter_key(key), to: Filtering
+    defdelegate sanitize_like(value), to: Filtering
+    defdelegate parse_order_dir(dir), to: Filtering
+    defdelegate parse_int(val), to: Filtering
 
     defp normalize_params(params, schema_module) do
       introspection = SchemaIntrospection.analyze(schema_module)
@@ -890,160 +854,13 @@ if Code.ensure_loaded?(Ecto) do
       end)
     end
 
-    @meta_keys ~w(order_by order_dir limit offset include_deleted)
-
-    @doc false
-    def extract_meta_params(params) do
-      {meta, filters} =
-        Enum.split_with(params, fn {key, _} -> to_string(key) in @meta_keys end)
-
-      {Map.new(meta, fn {k, v} -> {to_string(k), v} end), Map.new(filters)}
-    end
-
-    defp build_filter_query(schema_module, params, fields) do
-      import Ecto.Query
-
-      base_query = from(r in schema_module)
-
-      Enum.reduce(params, base_query, fn {field_str, value}, query ->
-        {field, operator} = parse_filter_key(to_string(field_str))
-
-        if field in fields do
-          apply_filter(query, field, operator, value)
-        else
-          query
-        end
-      end)
-    end
-
-    @doc false
-    def parse_filter_key(key) do
-      suffixes = ~w(_gte _gt _lte _lt _contains _icontains _in _not)
-
-      Enum.find_value(suffixes, {String.to_atom(key), :eq}, fn suffix ->
-        if String.ends_with?(key, suffix) do
-          base = String.replace_trailing(key, suffix, "")
-          op = suffix |> String.trim_leading("_") |> String.to_atom()
-          {String.to_atom(base), op}
-        end
-      end)
-    end
-
-    defp apply_filter(query, field, :eq, value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) == ^value)
-    end
-
-    defp apply_filter(query, field, :gt, value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) > ^value)
-    end
-
-    defp apply_filter(query, field, :gte, value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) >= ^value)
-    end
-
-    defp apply_filter(query, field, :lt, value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) < ^value)
-    end
-
-    defp apply_filter(query, field, :lte, value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) <= ^value)
-    end
-
-    defp apply_filter(query, field, :not, value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) != ^value)
-    end
-
-    defp apply_filter(query, field, :contains, value) do
-      import Ecto.Query
-      pattern = "%#{sanitize_like(value)}%"
-      where(query, [r], like(field(r, ^field), ^pattern))
-    end
-
-    defp apply_filter(query, field, :icontains, value) do
-      import Ecto.Query
-      pattern = "%#{sanitize_like(value)}%" |> String.downcase()
-      where(query, [r], like(fragment("LOWER(?)", field(r, ^field)), ^pattern))
-    end
-
-    defp apply_filter(query, field, :in, value) when is_list(value) do
-      import Ecto.Query
-      where(query, [r], field(r, ^field) in ^value)
-    end
-
-    defp apply_filter(query, _field, :in, _value), do: query
-
-    @doc false
-    def sanitize_like(value) do
-      value
-      |> to_string()
-      |> String.replace("\\", "\\\\")
-      |> String.replace("%", "\\%")
-      |> String.replace("_", "\\_")
-    end
-
-    defp apply_ordering(query, meta, fields) do
-      import Ecto.Query
-
-      case meta do
-        %{"order_by" => order_field} ->
-          field = String.to_atom(to_string(order_field))
-          dir = parse_order_dir(Map.get(meta, "order_dir", "asc"))
-
-          if field in fields do
-            order_by(query, [r], [{^dir, field(r, ^field)}])
-          else
-            query
-          end
-
-        _ ->
-          query
+    defp changeset_for(schema_module, struct, attrs, writable_fields) do
+      if function_exported?(schema_module, :changeset, 2) do
+        schema_module.changeset(struct, attrs)
+      else
+        Ecto.Changeset.cast(struct, attrs, writable_fields)
       end
     end
-
-    @doc false
-    def parse_order_dir(dir) when is_binary(dir) do
-      case String.downcase(dir) do
-        "desc" -> :desc
-        _ -> :asc
-      end
-    end
-
-    @doc false
-    def parse_order_dir(_), do: :asc
-
-    defp apply_pagination(query, meta, opts) do
-      import Ecto.Query
-
-      limit_val = parse_int(Map.get(meta, "limit")) || Keyword.get(opts, :limit, 100)
-      offset_val = parse_int(Map.get(meta, "offset")) || Keyword.get(opts, :offset, 0)
-
-      limit_val = min(limit_val, 100)
-
-      query
-      |> limit(^limit_val)
-      |> offset(^offset_val)
-    end
-
-    @doc false
-    def parse_int(nil), do: nil
-    @doc false
-    def parse_int(val) when is_integer(val), do: val
-    @doc false
-    def parse_int(val) when is_binary(val) do
-      case Integer.parse(val) do
-        {int, ""} -> int
-        _ -> nil
-      end
-    end
-
-    @doc false
-    def parse_int(_), do: nil
 
     @doc """
     Validates dynamic include requests against allowed preloadable associations.

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -154,7 +154,9 @@ if Code.ensure_loaded?(Ecto) do
           with_repo(opts, fn repo ->
             struct = struct(schema_module)
             attrs = normalize_params(params || %{}, schema_module)
-            changeset = changeset_for(schema_module, struct, attrs, writable_fields(schema_module))
+
+            changeset =
+              changeset_for(schema_module, struct, attrs, writable_fields(schema_module))
 
             case repo.insert(changeset) do
               {:ok, record} -> {:ok, record}

--- a/lib/ectomancer/repo/filtering.ex
+++ b/lib/ectomancer/repo/filtering.ex
@@ -1,0 +1,171 @@
+if Code.ensure_loaded?(Ecto) do
+  defmodule Ectomancer.Repo.Filtering do
+    @moduledoc false
+
+    import Ecto.Query
+
+    alias Ectomancer.SchemaIntrospection
+
+    @meta_keys ~w(order_by order_dir limit offset include_deleted)
+
+    @doc false
+    def extract_meta_params(params) do
+      {meta, filters} =
+        Enum.split_with(params, fn {key, _} -> to_string(key) in @meta_keys end)
+
+      {Map.new(meta, fn {k, v} -> {to_string(k), v} end), Map.new(filters)}
+    end
+
+    @doc false
+    def build_filter_query(schema_module, params, fields) do
+      base_query = from(r in schema_module)
+
+      Enum.reduce(params, base_query, fn {field_str, value}, query ->
+        {field, operator} = parse_filter_key(to_string(field_str))
+
+        if field in fields do
+          apply_filter(query, field, operator, value)
+        else
+          query
+        end
+      end)
+    end
+
+    @doc false
+    def parse_filter_key(key) do
+      suffixes = ~w(_gte _gt _lte _lt _contains _icontains _in _not)
+
+      Enum.find_value(suffixes, {String.to_atom(key), :eq}, fn suffix ->
+        if String.ends_with?(key, suffix) do
+          base = String.replace_trailing(key, suffix, "")
+          op = suffix |> String.trim_leading("_") |> String.to_atom()
+          {String.to_atom(base), op}
+        end
+      end)
+    end
+
+    defp apply_filter(query, field, :eq, value) do
+      where(query, [r], field(r, ^field) == ^value)
+    end
+
+    defp apply_filter(query, field, :gt, value) do
+      where(query, [r], field(r, ^field) > ^value)
+    end
+
+    defp apply_filter(query, field, :gte, value) do
+      where(query, [r], field(r, ^field) >= ^value)
+    end
+
+    defp apply_filter(query, field, :lt, value) do
+      where(query, [r], field(r, ^field) < ^value)
+    end
+
+    defp apply_filter(query, field, :lte, value) do
+      where(query, [r], field(r, ^field) <= ^value)
+    end
+
+    defp apply_filter(query, field, :not, value) do
+      where(query, [r], field(r, ^field) != ^value)
+    end
+
+    defp apply_filter(query, field, :contains, value) do
+      pattern = "%#{sanitize_like(value)}%"
+      where(query, [r], like(field(r, ^field), ^pattern))
+    end
+
+    defp apply_filter(query, field, :icontains, value) do
+      pattern = "%#{sanitize_like(value)}%" |> String.downcase()
+      where(query, [r], like(fragment("LOWER(?)", field(r, ^field)), ^pattern))
+    end
+
+    defp apply_filter(query, field, :in, value) when is_list(value) do
+      where(query, [r], field(r, ^field) in ^value)
+    end
+
+    defp apply_filter(query, _field, :in, _value), do: query
+
+    @doc false
+    def sanitize_like(value) do
+      value
+      |> to_string()
+      |> String.replace("\\", "\\\\")
+      |> String.replace("%", "\\%")
+      |> String.replace("_", "\\_")
+    end
+
+    @doc false
+    def apply_ordering(query, meta, fields) do
+      case meta do
+        %{"order_by" => order_field} ->
+          field = String.to_atom(to_string(order_field))
+          dir = parse_order_dir(Map.get(meta, "order_dir", "asc"))
+
+          if field in fields do
+            order_by(query, [r], [{^dir, field(r, ^field)}])
+          else
+            query
+          end
+
+        _ ->
+          query
+      end
+    end
+
+    @doc false
+    def parse_order_dir(dir) when is_binary(dir) do
+      case String.downcase(dir) do
+        "desc" -> :desc
+        _ -> :asc
+      end
+    end
+
+    @doc false
+    def parse_order_dir(_), do: :asc
+
+    @doc false
+    def apply_pagination(query, meta, opts) do
+      limit_val = parse_int(Map.get(meta, "limit")) || Keyword.get(opts, :limit, 100)
+      offset_val = parse_int(Map.get(meta, "offset")) || Keyword.get(opts, :offset, 0)
+
+      limit_val = min(limit_val, 100)
+
+      query
+      |> limit(^limit_val)
+      |> offset(^offset_val)
+    end
+
+    @doc false
+    def parse_int(nil), do: nil
+    @doc false
+    def parse_int(val) when is_integer(val), do: val
+    @doc false
+    def parse_int(val) when is_binary(val) do
+      case Integer.parse(val) do
+        {int, ""} -> int
+        _ -> nil
+      end
+    end
+
+    @doc false
+    def parse_int(_), do: nil
+
+    @doc false
+    def apply_soft_delete_filter(query, schema_module, meta_params) do
+      sd_field = SchemaIntrospection.soft_delete_field(schema_module)
+
+      if sd_field && !Map.get(meta_params, "include_deleted", false) do
+        where(query, [r], is_nil(field(r, ^sd_field)))
+      else
+        query
+      end
+    end
+
+    @doc false
+    def apply_scope(query, nil), do: query
+    def apply_scope(query, scope_fn) when is_function(scope_fn, 1), do: scope_fn.(query)
+  end
+else
+  defmodule Ectomancer.Repo.Filtering do
+    @moduledoc false
+  end
+end

--- a/lib/ectomancer/resource.ex
+++ b/lib/ectomancer/resource.ex
@@ -299,14 +299,8 @@ defmodule Ectomancer.Resource do
     )
   end
 
-  # Flatten nested __block__ items
   @doc false
-  def flatten_block_items(items) do
-    Enum.flat_map(items, fn
-      {:__block__, _, inner} -> flatten_block_items(inner)
-      other -> [other]
-    end)
-  end
+  defdelegate flatten_block_items(items), to: Ectomancer.Tool
 
   @doc false
   defdelegate parse_authorize_handler(handler), to: Ectomancer.Authorization, as: :parse_handler

--- a/lib/ectomancer/resource.ex
+++ b/lib/ectomancer/resource.ex
@@ -77,6 +77,8 @@ defmodule Ectomancer.Resource do
     a custom string (returned as generic error)
   """
 
+  alias Ectomancer.Authorization
+
   @doc """
   Defines a new resource within an Ectomancer module.
 
@@ -284,7 +286,7 @@ defmodule Ectomancer.Resource do
             {desc, uri, text, auth_handler, handler}
 
           {:authorize, _, [handler_ast]} ->
-            auth = parse_authorize_handler(handler_ast)
+            auth = Authorization.parse_handler(handler_ast)
             {desc, uri, mime, auth, handler}
 
           {:read, _, [handler_block]} ->
@@ -297,33 +299,6 @@ defmodule Ectomancer.Resource do
     )
   end
 
-  @doc false
-  def parse_authorize_handler(handler) do
-    case handler do
-      :none ->
-        nil
-
-      [with: module] ->
-        module
-
-      {:with, _, [module]} ->
-        module
-
-      {:fn, _, _} = fn_ast ->
-        fn_ast
-
-      {:&, _, _} = capture_ast ->
-        capture_ast
-
-      handler when is_function(handler) ->
-        handler
-
-      _ ->
-        raise ArgumentError,
-              "Invalid authorization handler. Use: authorize(fn actor, action -> ...), authorize(with: Module), or authorize(:none)"
-    end
-  end
-
   # Flatten nested __block__ items
   @doc false
   def flatten_block_items(items) do
@@ -332,4 +307,7 @@ defmodule Ectomancer.Resource do
       other -> [other]
     end)
   end
+
+  @doc false
+  defdelegate parse_authorize_handler(handler), to: Ectomancer.Authorization, as: :parse_handler
 end

--- a/lib/ectomancer/route_introspection.ex
+++ b/lib/ectomancer/route_introspection.ex
@@ -226,9 +226,9 @@ defmodule Ectomancer.RouteIntrospection do
 
     auth_handler =
       if Keyword.has_key?(opts, :authorize) do
-        Ectomancer.Expose.parse_auth_config(opts[:authorize])
+        Ectomancer.Authorization.parse_handler_for_global(opts[:authorize])
       else
-        Ectomancer.Expose.parse_auth_config(global_auth_raw)
+        Ectomancer.Authorization.parse_handler_for_global(global_auth_raw)
       end
 
     tool_definitions =
@@ -309,30 +309,10 @@ defmodule Ectomancer.RouteIntrospection do
   end
 
   @doc false
-  def generate_authorize_call(nil), do: quote(do: authorize(:none))
+  def generate_authorize_call(nil), do: Ectomancer.Authorization.authorize_to_ast(nil)
 
-  def generate_authorize_call(module) when is_atom(module) do
-    quote do
-      authorize(with: unquote(module))
-    end
-  end
-
-  def generate_authorize_call(handler) when is_function(handler) do
-    quote do
-      authorize(unquote(handler))
-    end
-  end
-
-  def generate_authorize_call({:fn, _, _} = fn_ast) do
-    quote do
-      authorize(unquote(fn_ast))
-    end
-  end
-
-  def generate_authorize_call({:&, _, _} = capture_ast) do
-    quote do
-      authorize(unquote(capture_ast))
-    end
+  def generate_authorize_call(handler) do
+    Ectomancer.Authorization.authorize_to_ast(handler)
   end
 
   @doc false

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -1,5 +1,5 @@
 if Code.ensure_loaded?(Ecto) do
-    defmodule Ectomancer.Tool do
+  defmodule Ectomancer.Tool do
     @moduledoc """
     Custom tool DSL for defining MCP tools.
 

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -1,5 +1,5 @@
 if Code.ensure_loaded?(Ecto) do
-  defmodule Ectomancer.Tool do
+    defmodule Ectomancer.Tool do
     @moduledoc """
     Custom tool DSL for defining MCP tools.
 
@@ -12,6 +12,8 @@ if Code.ensure_loaded?(Ecto) do
     Validation is handled internally rather than by Anubis's Peri validator
     to avoid JSON encoding issues with Peri's tuple-based schema format.
     """
+
+    alias Ectomancer.Authorization
 
     @doc """
     Defines a new tool within an Ectomancer module.
@@ -316,12 +318,12 @@ if Code.ensure_loaded?(Ecto) do
               {desc, [{name, type, opts} | params], auth_handler, parent_auth, handler}
 
             {:authorize, _, [handler, [parent_auth: parent]]} ->
-              auth_handler = parse_authorize_handler(handler)
-              parent_auth = parse_authorize_handler(parent)
+              auth_handler = Authorization.parse_handler(handler)
+              parent_auth = Authorization.parse_handler(parent)
               {desc, params, auth_handler, parent_auth, handler}
 
             {:authorize, _, [handler]} ->
-              auth_handler = parse_authorize_handler(handler)
+              auth_handler = Authorization.parse_handler(handler)
               {desc, params, auth_handler, parent_auth, handler}
 
             {:handle, _, [handler_block]} ->
@@ -332,32 +334,6 @@ if Code.ensure_loaded?(Ecto) do
           end
         end
       )
-    end
-
-    defp parse_authorize_handler(handler) do
-      case handler do
-        :none ->
-          nil
-
-        [with: module] ->
-          module
-
-        {:with, _, [module]} ->
-          module
-
-        {:fn, _, _} = fn_ast ->
-          fn_ast
-
-        {:&, _, _} = capture_ast ->
-          capture_ast
-
-        handler when is_function(handler) ->
-          handler
-
-        _ ->
-          raise ArgumentError,
-                "Invalid authorization handler. Use: authorize(fn actor, action -> ...), authorize(with: Module), or authorize(:none)"
-      end
     end
 
     # Flatten nested __block__ items

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -337,7 +337,8 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     # Flatten nested __block__ items
-    defp flatten_block_items(items) do
+    @doc false
+    def flatten_block_items(items) do
       Enum.flat_map(items, fn
         {:__block__, _, inner} -> flatten_block_items(inner)
         other -> [other]


### PR DESCRIPTION
6 commits, each targeting a specific area of improvement while keeping all 726 tests passing and verified against `ectomancer_demo`.

## Changes

### Phase 1: Extract `Ectomancer.Repo.Filtering`
- Move ~150 lines of filtering logic (query building, filter parsing, pagination, ordering, soft-delete) from `Ectomancer.Repo` (was 1174 lines) into a focused module
- Introduce shared `changeset_for/4` helper replacing 5 duplicated changeset-building patterns
- Keep backward-compatible delegation stubs for tested functions

### Phase 2: Extract `Ectomancer.Expose.Params` + `Ectomancer.Expose.Handlers`
- Move ~200 lines of param generation and ~130 lines of handler generation from `Ectomancer.Expose` (was 1144 lines → now 735)
- Make `get_ecto_type_for_param/1` public as shared utility

### Phase 3: Centralize authorization parsing
- Consolidate duplicated `parse_authorize_handler` / `parse_auth_config` / `oban_authorize_call` / `generate_authorize_call` spread across 5 modules
- Single implementation in `Ectomancer.Authorization` with `parse_handler/1`, `parse_handler_for_global/1`, and `authorize_to_ast/1`
- Remove ~80 lines of duplicated code

### Phase 4: Extract `Ectomancer.ObanBridge.Queries`
- Move ~210 lines of runtime SQL query logic into a focused module
- Keep backward-compatible delegation stubs

### Phase 5: Simplify `fetch_global_auth`
- Remove redundant case expression and unreachable branch

### Phase 6: Unify `flatten_block_items`
- Delegate from `Ectomancer.Resource` to `Ectomancer.Tool` instead of duplicating

## Verification
- ✅ All 726 unit tests pass
- ✅ All 10 integration tests in `ectomancer_demo` pass with this branch
- ✅ No breaking API changes (public interfaces preserved via delegations)