### PR TITLE
feat: per-action authorize option for expose_oban_jobs (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ expose MyApp.Accounts.User,
   ]
 ```
 
+Oban tools support the same per-action patterns:
+
+```elixir
+expose_oban_jobs authorize: [
+  all: fn actor, _ -> actor.role == :admin end,
+  list_queues: :none
+]
+```
+
 ## Configuration
 
 ### Sources

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -174,8 +174,6 @@ defmodule Ectomancer.Authorization do
 
   def parse_handler(with: module) when is_atom(module), do: module
 
-  def parse_handler(with: module) when is_atom(module), do: module
-
   def parse_handler(list) when is_list(list) do
     Keyword.get(list, :all) || Keyword.get(list, :global)
   end
@@ -237,7 +235,17 @@ defmodule Ectomancer.Authorization do
     * `nil`, `:none`, `:public` → `nil`
     * function or module → `%{global: handler, actions: %{}}`
     * keyword list with per-action rules → `%{global: handler, actions: %{action: handler}}`
+
+  ## Example
+
+      # Global admin-only auth, but list_queues is public:
+      expose_oban_jobs authorize: [
+        all: fn actor, _ -> actor.role == :admin end,
+        list_queues: :public
+      ]
   """
+  @spec parse_authorization_config(nil | :none | :public | atom() | function() | keyword()) ::
+          nil | %{global: term(), actions: map()}
   def parse_authorization_config(nil), do: nil
   def parse_authorization_config(:none), do: nil
   def parse_authorization_config(:public), do: nil

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -226,4 +226,35 @@ defmodule Ectomancer.Authorization do
     raise ArgumentError,
           "Invalid authorization handler AST: #{inspect(invalid)}"
   end
+
+  @doc """
+  Parses authorization configuration into a standard format.
+
+  Returns `nil` for no authorization, or a map with `:global` handler
+  and `:actions` for per-action handlers.
+
+  ## Forms
+    * `nil`, `:none`, `:public` → `nil`
+    * function or module → `%{global: handler, actions: %{}}`
+    * keyword list with per-action rules → `%{global: handler, actions: %{action: handler}}`
+  """
+  def parse_authorization_config(nil), do: nil
+  def parse_authorization_config(:none), do: nil
+  def parse_authorization_config(:public), do: nil
+
+  def parse_authorization_config(action_rules) when is_list(action_rules) do
+    global = Keyword.get(action_rules, :all) || Keyword.get(action_rules, :global)
+    global_handler = if global, do: parse_handler_for_global(global), else: nil
+
+    actions =
+      action_rules
+      |> Keyword.drop([:all, :global])
+      |> Map.new()
+
+    %{global: global_handler, actions: actions}
+  end
+
+  def parse_authorization_config(handler) do
+    %{global: parse_handler_for_global(handler), actions: %{}}
+  end
 end

--- a/lib/ectomancer/authorization.ex
+++ b/lib/ectomancer/authorization.ex
@@ -244,7 +244,7 @@ defmodule Ectomancer.Authorization do
         list_queues: :public
       ]
   """
-  @spec parse_authorization_config(nil | :none | :public | atom() | function() | keyword()) ::
+  @spec parse_authorization_config(nil | :none | :public | function() | keyword()) ::
           nil | %{global: term(), actions: map()}
   def parse_authorization_config(nil), do: nil
   def parse_authorization_config(:none), do: nil

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -248,8 +248,8 @@ if Code.ensure_loaded?(Ecto) do
       introspection = SchemaIntrospection.analyze(schema)
 
       auth_explicitly_configured = Keyword.has_key?(opts, :authorize)
-      auth_config = parse_authorization_config(Keyword.get(opts, :authorize))
-      parent_authorization = parse_authorization_config(global_auth_raw)
+      auth_config = Authorization.parse_authorization_config(Keyword.get(opts, :authorize))
+      parent_authorization = Authorization.parse_authorization_config(global_auth_raw)
       readonly = Keyword.get(opts, :readonly, false)
 
       base_actions = Keyword.get(opts, :actions, [:list, :get, :create, :update, :destroy])
@@ -317,26 +317,6 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp filter_actions_for_readonly(actions, _), do: actions
-
-    defp parse_authorization_config(nil), do: nil
-    defp parse_authorization_config(:none), do: nil
-    defp parse_authorization_config(:public), do: nil
-
-    defp parse_authorization_config(action_rules) when is_list(action_rules) do
-      global = Keyword.get(action_rules, :all) || Keyword.get(action_rules, :global)
-      global_handler = if global, do: Authorization.parse_handler_for_global(global), else: nil
-
-      actions =
-        action_rules
-        |> Keyword.drop([:all, :global])
-        |> Map.new()
-
-      %{global: global_handler, actions: actions}
-    end
-
-    defp parse_authorization_config(handler) do
-      %{global: Authorization.parse_handler_for_global(handler), actions: %{}}
-    end
 
     @doc false
     def parse_auth_config(nil), do: nil

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -70,16 +70,13 @@ if Code.ensure_loaded?(Oban) do
       if Code.ensure_loaded?(Oban) do
         namespace = Keyword.get(opts, :namespace)
 
-        global_auth_raw = Ectomancer.fetch_global_auth(__CALLER__.module)
+        auth_config =
+          build_oban_auth_config(
+            Keyword.get(opts, :authorize),
+            Ectomancer.fetch_global_auth(__CALLER__.module)
+          )
 
-        auth_handler =
-          if Keyword.has_key?(opts, :authorize) do
-            Ectomancer.Authorization.parse_handler_for_global(opts[:authorize])
-          else
-            Ectomancer.Authorization.parse_handler_for_global(global_auth_raw)
-          end
-
-        generate_oban_tools(namespace, auth_handler)
+        generate_oban_tools(namespace, auth_config)
       else
         # Oban not available, generate nothing
         quote do
@@ -88,14 +85,57 @@ if Code.ensure_loaded?(Oban) do
       end
     end
 
+    defp build_oban_auth_config(nil, global_raw) do
+      %{handler: Ectomancer.Authorization.parse_handler_for_global(global_raw), actions: %{}}
+    end
+
+    defp build_oban_auth_config(authorize, global_raw) when is_list(authorize) do
+      config = Ectomancer.Authorization.parse_authorization_config(authorize)
+
+      actions =
+        Map.new(config.actions, fn {action, handler} ->
+          resolved =
+            case handler do
+              :none -> nil
+              :public -> nil
+              other -> Ectomancer.Authorization.parse_handler_for_global(other)
+            end
+
+          {action, resolved}
+        end)
+
+      %{
+        handler: config.global || Ectomancer.Authorization.parse_handler_for_global(global_raw),
+        actions: actions
+      }
+    end
+
+    defp build_oban_auth_config(authorize, _global_raw) do
+      %{handler: Ectomancer.Authorization.parse_handler_for_global(authorize), actions: %{}}
+    end
+
+    defp resolve_oban_handler(action, %{handler: global, actions: actions}) do
+      if Map.has_key?(actions, action) do
+        Map.get(actions, action)
+      else
+        global
+      end
+    end
+
     # Generate all Oban management tools
-    defp generate_oban_tools(namespace, auth_handler) do
+    defp generate_oban_tools(namespace, auth_config) do
       tools = [
-        generate_list_queues_tool(namespace, auth_handler),
-        generate_get_queue_depth_tool(namespace, auth_handler),
-        generate_list_stuck_jobs_tool(namespace, auth_handler),
-        generate_retry_job_tool(namespace, auth_handler),
-        generate_cancel_job_tool(namespace, auth_handler)
+        generate_list_queues_tool(namespace, resolve_oban_handler(:list_queues, auth_config)),
+        generate_get_queue_depth_tool(
+          namespace,
+          resolve_oban_handler(:get_queue_depth, auth_config)
+        ),
+        generate_list_stuck_jobs_tool(
+          namespace,
+          resolve_oban_handler(:list_stuck_jobs, auth_config)
+        ),
+        generate_retry_job_tool(namespace, resolve_oban_handler(:retry_job, auth_config)),
+        generate_cancel_job_tool(namespace, resolve_oban_handler(:cancel_job, auth_config))
       ]
 
       quote do

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -105,6 +105,7 @@ if Code.ensure_loaded?(Oban) do
         end)
 
       %{
+        # Falls back to global auth (from use Ectomancer) if :all/:global not set in keyword list
         handler: config.global || Ectomancer.Authorization.parse_handler_for_global(global_raw),
         actions: actions
       }

--- a/lib/ectomancer/oban_bridge.ex
+++ b/lib/ectomancer/oban_bridge.ex
@@ -44,9 +44,15 @@ if Code.ensure_loaded?(Oban) do
 
     ## Authorization
 
-    By default, Oban tools are public (no authorization). You can add
-    authorization by wrapping the macro call or by implementing custom
-    authorization at the MCP module level.
+    By default, Oban tools are public (no authorization). Add a global
+    policy with `authorize:`, or use action-specific rules:
+
+        expose_oban_jobs(authorize: fn actor, _ -> actor.role == :admin end)
+
+        expose_oban_jobs authorize: [
+          all: fn actor, _ -> actor.role == :admin end,
+          list_queues: :none
+        ]
     """
 
     alias Ectomancer.ObanBridge.Queries
@@ -57,6 +63,7 @@ if Code.ensure_loaded?(Oban) do
     ## Options
 
       * `:namespace` - Prefix tool names with namespace (e.g., `:background` → `background_list_oban_queues`)
+      * `:authorize` - Authorization configuration (function, policy module, or action-specific rules)
 
     ## Examples
 
@@ -65,6 +72,11 @@ if Code.ensure_loaded?(Oban) do
 
         expose_oban_jobs(namespace: :jobs)
         # Generates: jobs_list_oban_queues, jobs_get_queue_depth, etc.
+
+        expose_oban_jobs authorize: [
+          all: fn actor, _ -> actor.role == :admin end,
+          list_queues: :none
+        ]
     """
     defmacro expose_oban_jobs(opts \\ []) do
       if Code.ensure_loaded?(Oban) do

--- a/test/ectomancer/oban_bridge_test.exs
+++ b/test/ectomancer/oban_bridge_test.exs
@@ -545,5 +545,110 @@ defmodule Ectomancer.ObanBridgeTest do
       # Should not get auth error (per-call :none overrides global)
       refute match?({:error, %{code: -32_001}, _}, result)
     end
+
+    test "per-action keyword list applies different auth to different tools" do
+      defmodule PerActionObanMCP do
+        use Ectomancer,
+          name: "per-action-oban-mcp",
+          version: "1.0.0"
+
+        expose_oban_jobs(
+          authorize: [
+            list_queues: :public,
+            cancel_job: fn actor, _action -> actor.role == :admin end
+          ]
+        )
+      end
+
+      # list_queues should be public (no auth): a non-admin should pass
+      assert {:module, list_mod} = Code.ensure_loaded(PerActionObanMCP.Tool.ListObanQueues)
+
+      frame_admin = %{assigns: %{ectomancer_actor: %{role: :admin}}}
+      frame_user = %{assigns: %{ectomancer_actor: %{role: :user}}}
+
+      # credo:disable-for-next-line
+      result = apply(list_mod, :execute, [%{}, frame_user])
+      refute match?({:error, %{code: -32_001}, _}, result)
+
+      # cancel_job should be restricted to admin: a non-admin should be denied
+      assert {:module, cancel_mod} = Code.ensure_loaded(PerActionObanMCP.Tool.CancelJob)
+
+      # credo:disable-for-next-line
+      assert {:error, error, _} = apply(cancel_mod, :execute, [%{}, frame_user])
+      assert error.code == -32_001
+      assert error.message =~ "Unauthorized"
+
+      # Admin should be allowed for cancel_job
+      # credo:disable-for-next-line
+      result_admin = apply(cancel_mod, :execute, [%{}, frame_admin])
+      refute match?({:error, %{code: -32_001}, _}, result_admin)
+    end
+
+    test "per-action keyword list with :none for specific action" do
+      defmodule PerActionNoneObanMCP do
+        use Ectomancer,
+          name: "per-action-none-oban-mcp",
+          version: "1.0.0",
+          authorize: fn _actor, _action -> false end
+
+        expose_oban_jobs(
+          authorize: [
+            list_queues: :none
+          ]
+        )
+      end
+
+      # list_queues should have no auth (overriding global deny)
+      assert {:module, list_mod} = Code.ensure_loaded(PerActionNoneObanMCP.Tool.ListObanQueues)
+
+      frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
+
+      # credo:disable-for-next-line
+      result = apply(list_mod, :execute, [%{}, frame])
+      refute match?({:error, %{code: -32_001}, _}, result)
+
+      # cancel_job should still be denied by global auth
+      assert {:module, cancel_mod} = Code.ensure_loaded(PerActionNoneObanMCP.Tool.CancelJob)
+
+      # credo:disable-for-next-line
+      assert {:error, error, _} = apply(cancel_mod, :execute, [%{}, frame])
+      assert error.code == -32_001
+    end
+
+    test "per-action keyword list with :all global fallback" do
+      defmodule PerActionAllObanMCP do
+        use Ectomancer,
+          name: "per-action-all-oban-mcp",
+          version: "1.0.0"
+
+        expose_oban_jobs(
+          authorize: [
+            all: fn actor, _action -> actor.role == :admin end,
+            list_queues: :public
+          ]
+        )
+      end
+
+      assert {:module, list_mod} = Code.ensure_loaded(PerActionAllObanMCP.Tool.ListObanQueues)
+      assert {:module, cancel_mod} = Code.ensure_loaded(PerActionAllObanMCP.Tool.CancelJob)
+
+      frame_user = %{assigns: %{ectomancer_actor: %{role: :user}}}
+      frame_admin = %{assigns: %{ectomancer_actor: %{role: :admin}}}
+
+      # list_queues is public: non-admin should pass
+      # credo:disable-for-next-line
+      result = apply(list_mod, :execute, [%{}, frame_user])
+      refute match?({:error, %{code: -32_001}, _}, result)
+
+      # cancel_job falls back to :all (admin only): non-admin should be denied
+      # credo:disable-for-next-line
+      assert {:error, error, _} = apply(cancel_mod, :execute, [%{}, frame_user])
+      assert error.code == -32_001
+
+      # admin should pass for cancel_job
+      # credo:disable-for-next-line
+      result_admin = apply(cancel_mod, :execute, [%{}, frame_admin])
+      refute match?({:error, %{code: -32_001}, _}, result_admin)
+    end
   end
 end


### PR DESCRIPTION
Closes #103

## Summary

Adds per-action keyword list authorization support to `expose_oban_jobs`, enabling granular control over individual Oban tools.

## Changes

### `lib/ectomancer/authorization.ex`
- Added public `parse_authorization_config/1` — normalizes authorization config from any form (nil, :none, :public, fn, module, keyword list) into a standard `%{global: handler, actions: %{action: handler}}` map. Mirrors the private `Expose.parse_authorization_config/1` but available in the public API.

### `lib/ectomancer/oban_bridge.ex`
- Replaced simple `auth_handler` with `auth_config` parsing via `build_oban_auth_config/2`:
  - `nil` — falls back to global auth from `use Ectomancer`
  - keyword list — parses per-action handlers, uses `:all`/`:global` from the list or falls back to global auth
  - other (fn/module) — applies to all tools uniformly
- Added `resolve_oban_handler/2` — uses `Map.has_key?` to correctly distinguish "action explicitly set to nil (no auth via :none/:public)" from "action not in list (fallback to global)"
- Each tool receives its resolved handler independently via `resolve_oban_handler(:action_name, auth_config)`

### `test/ectomancer/oban_bridge_test.exs`
- Test: per-action different auth (public `list_queues`, admin-only `cancel_job`)
- Test: per-action `:none` override of global deny
- Test: per-action with `:all` as fallback for unspecified actions

## Verification
- ✅ 758 tests pass
- ✅ `mix format --check-formatted` clean
- ✅ `mix credo` clean (no issues)