### PR TITLE
feat: MCP Prompt support via prompt/2 macro (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ectomancer sits on top of [anubis_mcp](https://hex.pm/packages/anubis_mcp) and t
 - **Upsert operations** — `upsert_{resource}` for insert-or-update workflows with conflict target and `on_conflict` control
 - **Batch operations** — `batch_create`, `batch_update`, `batch_destroy` for transactional multi-record operations
 - **Custom resources** — `resource :system_status do ... end` with URI templates, MIME types, and authorization
+- **MCP Prompts** — `prompt :analyze_churn do ... end` for structured, parameterized prompt templates with argument validation
 - **Rate limiting** — configurable token bucket per tool or globally
 - **Multi-repo support** — expose schemas from different repos simultaneously
 - **MCP Resources** — schemas auto-register at `ectomancer://schemas/{name}`, plus custom resources with URI templates, MIME types, and read handlers
@@ -121,6 +122,24 @@ defmodule MyApp.MCP do
 
     read fn _params, _actor ->
       {:ok, Jason.encode!(%{status: "healthy", uptime: System.uptime()})}
+    end
+  end
+
+  prompt :analyze_churn do
+    description "Analyze user churn over a time period"
+    argument :days, :integer, required: true, description: "Days to look back"
+    argument :threshold, :float, default: 0.05, description: "Churn threshold"
+
+    messages fn args ->
+      [
+        %{
+          role: :user,
+          content: %{
+            type: :text,
+            text: "Using the list_users and get_user tools, analyze churn over the last #{args["days"]} days with threshold #{args["threshold"]}."
+          }
+        }
+      ]
     end
   end
 end
@@ -436,6 +455,43 @@ expose MyApp.Accounts.User,
 ```
 
 Upsert is **soft-delete aware** — upserting onto a soft-deleted record restores it (sets `deleted_at` to `nil`).
+
+## Prompts
+
+Define structured, parameterized prompt templates for LLM clients. Prompts are reusable blueprints that generate messages based on runtime arguments — the AI assistant can request them to kick off common workflows.
+
+```elixir
+prompt :summarize_reports do
+  description "Summarize recent reports by type"
+  argument :report_type, :string,
+    required: true,
+    description: "Type of report",
+    enum: ["sales", "inventory", "employee"]
+
+  messages fn args ->
+    report_type = Map.get(args, "report_type", "sales")
+
+    [
+      %{
+        role: :system,
+        content: %{
+          type: :text,
+          text: "You are a report analyst. Summarize the #{report_type} reports."
+        }
+      },
+      %{
+        role: :user,
+        content: %{
+          type: :text,
+          text: "Provide a concise summary of the latest #{report_type} reports."
+        }
+      }
+    ]
+  end
+end
+```
+
+Prompts integrate with the MCP `prompts/list` and `prompts/get` protocol methods via `Anubis.Server.component/2`. Arguments support `required`, `default`, `description`, and `enum` constraints.
 
 ## Pages
 

--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -60,6 +60,8 @@ defmodule Ectomancer do
   - `expose/2` - Auto-generate CRUD tools from Ecto schemas
   - `expose_routes/1` - Auto-generate tools from Phoenix router routes
   - `expose_oban_jobs/0` - Auto-generate Oban job management tools (requires Oban)
+  - `resource/2` - Define custom MCP resources with URI templates, MIME types, and handlers
+  - `prompt/2` - Define MCP prompt templates with typed arguments and message callbacks
   - `authorize/1` - Add authorization to tools (use inside tool block)
 
   ## Authorization

--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -200,7 +200,7 @@ defmodule Ectomancer do
       use Anubis.Server,
         name: Keyword.get(unquote(opts), :name, "ectomancer-server"),
         version: Keyword.get(unquote(opts), :version, "0.1.0"),
-        capabilities: [:tools, :resources]
+        capabilities: [:tools, :resources, :prompts]
 
       Module.register_attribute(__MODULE__, :ectomancer_resources, accumulate: true)
 
@@ -209,6 +209,7 @@ defmodule Ectomancer do
 
       import Ectomancer.Tool, only: [tool: 2, authorize: 1]
       import Ectomancer.Resource, only: [resource: 2]
+      import Ectomancer.Prompt, only: [prompt: 2]
       import Ectomancer.Expose, only: [expose: 1, expose: 2]
       import Ectomancer.RouteIntrospection, only: [expose_routes: 1, expose_routes: 2]
       import Ectomancer.ObanBridge, only: [expose_oban_jobs: 0, expose_oban_jobs: 1]

--- a/lib/ectomancer/prompt.ex
+++ b/lib/ectomancer/prompt.ex
@@ -145,12 +145,14 @@ defmodule Ectomancer.Prompt do
         @moduledoc unquote(description)
         @prompt_name unquote(prompt_name)
         @arguments unquote(arguments)
+        @raw_schema Ectomancer.Prompt.build_prompt_schema(unquote(arguments))
         @messages_fn unquote(messages_ast)
 
         def name, do: @prompt_name
         def description, do: @moduledoc
         def __mcp_component_type__, do: :prompt
         def __scopes__, do: []
+        def __mcp_raw_schema__, do: @raw_schema
 
         def arguments do
           @arguments
@@ -253,13 +255,15 @@ defmodule Ectomancer.Prompt do
   end
 
   # Build argument definition for MCP protocol
-  defp build_argument_def(name, _type, opts) do
+  defp build_argument_def(name, type, opts) do
     arg_name = to_string(name)
 
     arg = %{
       "name" => arg_name,
       "description" => opts[:description] || "",
-      "required" => opts[:required] || false
+      "required" => opts[:required] || false,
+      "_type" => type,
+      "_name" => name
     }
 
     arg =
@@ -278,6 +282,27 @@ defmodule Ectomancer.Prompt do
 
     arg
   end
+
+  @doc false
+  def build_prompt_schema(arguments) do
+    Enum.reduce(arguments, %{}, fn arg, acc ->
+      name = arg["name"]
+      type = arg["_type"]
+      required = arg["required"]
+
+      peri_type = prompt_type_to_peri(type)
+      field_type = if required, do: {:required, peri_type}, else: peri_type
+      Map.put(acc, name, field_type)
+    end)
+  end
+
+  defp prompt_type_to_peri(:string), do: :string
+  defp prompt_type_to_peri(:integer), do: :integer
+  defp prompt_type_to_peri(:float), do: :float
+  defp prompt_type_to_peri(:boolean), do: :boolean
+  defp prompt_type_to_peri(:list), do: {:list, :string}
+  defp prompt_type_to_peri(:map), do: :map
+  defp prompt_type_to_peri(_), do: :string
 
   @doc false
   def flatten_block_items(items) do

--- a/lib/ectomancer/prompt.ex
+++ b/lib/ectomancer/prompt.ex
@@ -1,0 +1,291 @@
+# credo:disable-for-this-file Credo.Check.Refactor.FunctionArity
+defmodule Ectomancer.Prompt do
+  @moduledoc """
+  Prompt DSL for defining MCP prompt templates.
+
+  Prompts are reusable templates that generate messages based on provided
+  arguments. They enable structured, parameterized interactions with LLM clients.
+
+  ## Examples
+
+      defmodule MyApp.MCP do
+        use Ectomancer, name: "my-app", version: "1.0.0"
+
+        prompt :analyze_churn do
+          description "Analyze user churn over a time period"
+          argument :days, :integer, required: true, description: "Days to look back"
+          argument :threshold, :float, default: 0.05, description: "Churn threshold"
+
+          messages fn args ->
+            [
+              %{
+                role: "user",
+                content: %{
+                  type: "text",
+                  text: "Using the list_users tool, analyze churn over the last \#{args.days} days with threshold \#{args.threshold}..."
+                }
+              }
+            ]
+          end
+        end
+
+        prompt :summarize_reports do
+          description "Summarize recent reports"
+          argument :report_type, :string, required: true,
+                    description: "Type of report",
+                    enum: ["sales", "inventory", "employee"]
+
+          messages fn args ->
+            report_type = Map.get(args, "report_type", "sales")
+
+            [
+              %{
+                role: "system",
+                content: %{
+                  type: "text",
+                  text: "You are a report analyst. Summarize the \#{report_type} reports."
+                }
+              },
+              %{
+                role: "user",
+                content: %{
+                  type: "text",
+                  text: "Provide a concise summary of the latest \#{report_type} reports."
+                }
+              }
+            ]
+          end
+        end
+      end
+
+  ## DSL Functions
+
+  - `description/1` — Human-readable description of the prompt
+  - `argument/3` — Define an argument with name, type, and options
+    - `:required` — Whether the argument is required (default: `false`)
+    - `:description` — Description of the argument
+    - `:default` — Default value if not provided
+    - `:enum` — List of allowed values
+  - `messages/1` — Callback `fn args -> [...] end` that returns a list of message maps
+    Each message is `%{role: "user"|"assistant"|"system", content: %{type: "text", text: "..."}}`
+
+  ## Arguments
+
+  Arguments support the following types: `:string`, `:integer`, `:float`, `:boolean`,
+  `:list`, `:map`, and arrays (`{:array, inner_type}`).
+
+  Arguments with `required: true` will be validated by Anubis MCP before calling
+  the `messages` callback. Missing required arguments will return a protocol error.
+
+  ## Response Format
+
+  The `messages` callback should return a list of message maps. Each message must have:
+  - `:role` — One of `"user"`, `"assistant"`, or `"system"`
+  - `:content` — A map with `:type` (`"text"`) and `:text` (the message content)
+
+  The generated module wraps these messages in an `Anubis.Server.Response` struct
+  with `type: :prompt` for proper MCP protocol encoding.
+  """
+
+  @doc """
+  Defines a new prompt within an Ectomancer module.
+
+  ## Example
+
+      prompt :analyze_churn do
+        description "Analyze user churn over a time period"
+        argument :days, :integer, required: true, description: "Days to look back"
+
+        messages fn args ->
+          [
+            %{
+              role: "user",
+              content: %{
+                type: "text",
+                text: "Analyze churn over the last \#{args["days"]} days"
+              }
+            }
+          ]
+        end
+      end
+  """
+  defmacro prompt(name, do: block) do
+    prompt_name_str = to_string(name)
+
+    {description, arguments, messages_ast} = parse_prompt_block(block)
+
+    quote do
+      prompt_module_name =
+        Module.concat(__MODULE__, "Prompt.#{Macro.camelize(unquote(prompt_name_str))}")
+
+      Ectomancer.Prompt.define_prompt_module(
+        prompt_module_name,
+        unquote(prompt_name_str),
+        unquote(Macro.escape(description)),
+        unquote(Macro.escape(arguments)),
+        unquote(messages_ast)
+      )
+
+      require Anubis.Server
+      Anubis.Server.component(prompt_module_name, name: unquote(prompt_name_str))
+    end
+  end
+
+  @doc false
+  defmacro define_prompt_module(
+               module_name,
+               prompt_name,
+               description,
+               arguments,
+               messages_ast
+             ) do
+    quote do
+      defmodule unquote(module_name) do
+        @moduledoc unquote(description)
+        @prompt_name unquote(prompt_name)
+        @arguments unquote(arguments)
+        @messages_fn unquote(messages_ast)
+
+        def name, do: @prompt_name
+        def description, do: @moduledoc
+        def __mcp_component_type__, do: :prompt
+        def __scopes__, do: []
+
+        def arguments do
+          @arguments
+        end
+
+        def get_messages(args, frame) do
+          validated_args = apply_defaults(@arguments, args || %{})
+
+          try do
+            messages = unquote(messages_ast).(validated_args)
+
+            response =
+              %Anubis.Server.Response{
+                type: :prompt,
+                messages: Enum.map(messages, &message_to_protocol/1)
+              }
+
+            {:reply, response, frame}
+          rescue
+            e ->
+              error = %Anubis.MCP.Error{
+                code: -32_603,
+                message: "Prompt execution error: #{Exception.message(e)}",
+                data: %{
+                  error: inspect(e),
+                  stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+                }
+              }
+
+              {:error, error, frame}
+          end
+        end
+
+        defp message_to_protocol(%{role: role, content: %{type: type, text: text}})
+             when role in ~w(user assistant system)a and type in ~w(text)a do
+          %{"role" => to_string(role), "content" => %{"type" => to_string(type), "text" => text}}
+        end
+
+        defp message_to_protocol(msg) when is_map(msg) do
+          msg
+          |> Map.new(fn {k, v} -> {to_string(k), v} end)
+          |> maybe_wraps_content()
+        end
+
+        defp maybe_wraps_content(%{"content" => %{"text" => _} = content} = msg) do
+          msg
+        end
+
+        defp maybe_wraps_content(%{"content" => content} = msg) when is_binary(content) do
+          Map.put(msg, "content", %{"type" => "text", "text" => content})
+        end
+
+        defp maybe_wraps_content(msg), do: msg
+
+        defp apply_defaults(arguments, args) do
+          Enum.reduce(arguments, args, fn arg, acc ->
+            name = arg["name"]
+            default = arg["default"]
+
+            if is_nil(Map.get(acc, name)) and not is_nil(default) do
+              Map.put(acc, name, default)
+            else
+              acc
+            end
+          end)
+        end
+      end
+    end
+  end
+
+  # Parse prompt block to extract components
+  defp parse_prompt_block(block) do
+    items =
+      case block do
+        {:__block__, _, inner_items} -> flatten_block_items(inner_items)
+        single -> [single]
+      end
+
+    Enum.reduce(
+      items,
+      {"", [], quote(do: fn _args -> [] end)},
+      fn item, {desc, arguments, messages} ->
+        case item do
+          {:description, _, [text]} ->
+            {text, arguments, messages}
+
+          {:argument, _, [name, type | rest]} ->
+            opts = extract_opts(rest)
+            arg = build_argument_def(name, type, opts)
+            {desc, [arg | arguments], messages}
+
+          {:messages, _, [messages_block]} ->
+            {desc, arguments, messages_block}
+
+          _ ->
+            {desc, arguments, messages}
+        end
+      end
+    )
+  end
+
+  # Build argument definition for MCP protocol
+  defp build_argument_def(name, _type, opts) do
+    arg_name = to_string(name)
+
+    arg = %{
+      "name" => arg_name,
+      "description" => opts[:description] || "",
+      "required" => opts[:required] || false
+    }
+
+    arg =
+      if opts[:default] do
+        Map.put(arg, "default", opts[:default])
+      else
+        arg
+      end
+
+    arg =
+      if opts[:enum] do
+        Map.put(arg, "enum", opts[:enum])
+      else
+        arg
+      end
+
+    arg
+  end
+
+  @doc false
+  def flatten_block_items(items) do
+    Enum.flat_map(items, fn
+      {:__block__, _, inner} -> flatten_block_items(inner)
+      other -> [other]
+    end)
+  end
+
+  defp extract_opts([]), do: []
+  defp extract_opts([opts | _]), do: opts
+end

--- a/lib/ectomancer/prompt.ex
+++ b/lib/ectomancer/prompt.ex
@@ -132,6 +132,7 @@ defmodule Ectomancer.Prompt do
   end
 
   @doc false
+  # credo:disable-for-next-line
   defmacro define_prompt_module(
              module_name,
              prompt_name,

--- a/lib/ectomancer/prompt.ex
+++ b/lib/ectomancer/prompt.ex
@@ -133,12 +133,12 @@ defmodule Ectomancer.Prompt do
 
   @doc false
   defmacro define_prompt_module(
-               module_name,
-               prompt_name,
-               description,
-               arguments,
-               messages_ast
-             ) do
+             module_name,
+             prompt_name,
+             description,
+             arguments,
+             messages_ast
+           ) do
     quote do
       defmodule unquote(module_name) do
         @moduledoc unquote(description)

--- a/test/ectomancer/plug_integration_test.exs
+++ b/test/ectomancer/plug_integration_test.exs
@@ -294,12 +294,13 @@ defmodule Ectomancer.PlugIntegrationTest do
       ref = make_ref()
 
       capture_log(fn ->
-        result = WSPlug.connect(%{
-          endpoint: nil,
-          transport: :websocket,
-          params: %{},
-          options: []
-        })
+        result =
+          WSPlug.connect(%{
+            endpoint: nil,
+            transport: :websocket,
+            params: %{},
+            options: []
+          })
 
         send(self(), {ref, result})
       end)

--- a/test/ectomancer/plug_integration_test.exs
+++ b/test/ectomancer/plug_integration_test.exs
@@ -2,6 +2,7 @@ defmodule Ectomancer.PlugIntegrationTest do
   use ExUnit.Case
   import Plug.Conn
   import Plug.Test
+  import ExUnit.CaptureLog
 
   alias Ectomancer.Plug, as: EctomancerPlug
   alias Ectomancer.Plug.WebSocket, as: WSPlug
@@ -290,15 +291,20 @@ defmodule Ectomancer.PlugIntegrationTest do
     end
 
     test "connect with missing server option returns error" do
-      result =
-        WSPlug.connect(%{
+      ref = make_ref()
+
+      capture_log(fn ->
+        result = WSPlug.connect(%{
           endpoint: nil,
           transport: :websocket,
           params: %{},
           options: []
         })
 
-      assert result == {:error, :missing_server_option}
+        send(self(), {ref, result})
+      end)
+
+      assert_receive {^ref, {:error, :missing_server_option}}
     end
   end
 end

--- a/test/ectomancer/prompt_test.exs
+++ b/test/ectomancer/prompt_test.exs
@@ -110,6 +110,7 @@ defmodule Ectomancer.PromptTest do
     def description, do: "A prompt that crashes"
     def __mcp_component_type__, do: :prompt
     def __scopes__, do: []
+    def __mcp_raw_schema__, do: %{}
 
     def arguments, do: []
 
@@ -359,6 +360,104 @@ defmodule Ectomancer.PromptTest do
       assert length(response.messages) == 2
       assert Enum.any?(response.messages, &(&1["role"] == "system"))
       assert Enum.any?(response.messages, &(&1["role"] == "user"))
+    end
+  end
+
+  describe "end-to-end: MCP protocol via handle_request/2" do
+    test "prompts/list returns registered prompts" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, result, _frame} =
+        PromptMCP.handle_request(%{"method" => "prompts/list"}, frame)
+
+      prompt_names = result["prompts"] |> Enum.map(& &1.name)
+
+      assert "analyze_churn" in prompt_names
+      assert "summarize_reports" in prompt_names
+      assert "simple_prompt" in prompt_names
+      assert "prompt_with_actor" in prompt_names
+    end
+
+    test "prompts/get resolves and returns generated messages" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, result, _frame} =
+        PromptMCP.handle_request(
+          %{
+            "method" => "prompts/get",
+            "params" => %{
+              "name" => "analyze_churn",
+              "arguments" => %{"days" => 30, "threshold" => 0.1}
+            }
+          },
+          frame
+        )
+
+      messages = result["messages"]
+      assert length(messages) == 1
+      assert hd(messages)["role"] == "user"
+      assert hd(messages)["content"]["text"] =~ "30"
+      assert hd(messages)["content"]["text"] =~ "0.1"
+    end
+
+    test "prompts/get applies default arguments through the protocol" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, result, _frame} =
+        PromptMCP.handle_request(
+          %{
+            "method" => "prompts/get",
+            "params" => %{
+              "name" => "analyze_churn",
+              "arguments" => %{"days" => 7}
+            }
+          },
+          frame
+        )
+
+      messages = result["messages"]
+      assert hd(messages)["content"]["text"] =~ "7"
+      assert hd(messages)["content"]["text"] =~ "0.05"
+    end
+
+    test "prompts/get returns error for unknown prompt" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:error, error, _frame} =
+        PromptMCP.handle_request(
+          %{
+            "method" => "prompts/get",
+            "params" => %{
+              "name" => "nonexistent",
+              "arguments" => %{}
+            }
+          },
+          frame
+        )
+
+      assert error.code == -32_602
+    end
+
+    test "prompts/get returns multi-message prompts through the protocol" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, result, _frame} =
+        PromptMCP.handle_request(
+          %{
+            "method" => "prompts/get",
+            "params" => %{
+              "name" => "summarize_reports",
+              "arguments" => %{"report_type" => "sales"}
+            }
+          },
+          frame
+        )
+
+      messages = result["messages"]
+      assert length(messages) == 2
+      assert Enum.any?(messages, &(&1["role"] == "system"))
+      assert Enum.any?(messages, &(&1["role"] == "user"))
+      assert hd(Enum.filter(messages, &(&1["role"] == "system")))["content"]["text"] =~ "sales"
     end
   end
 end

--- a/test/ectomancer/prompt_test.exs
+++ b/test/ectomancer/prompt_test.exs
@@ -1,0 +1,300 @@
+# credo:disable-for-this-file Credo.Check.Design.AliasUsage
+defmodule Ectomancer.PromptTest do
+  use ExUnit.Case
+  doctest Ectomancer.Prompt
+
+  defmodule TestUser do
+    use Ecto.Schema
+
+    schema "test_users" do
+      field(:name, :string)
+      field(:email, :string)
+      timestamps()
+    end
+  end
+
+  defmodule PromptMCP do
+    use Ectomancer, name: "prompt-test", version: "1.0.0"
+
+    expose(
+      Ectomancer.PromptTest.TestUser,
+      actions: [:list, :get]
+    )
+
+    prompt :analyze_churn do
+      description("Analyze user churn over a time period")
+      argument(:days, :integer, required: true, description: "Days to look back")
+      argument(:threshold, :float, default: 0.05, description: "Churn threshold")
+
+      messages fn args ->
+        [
+          %{
+            role: :user,
+            content: %{
+              type: :text,
+              text: "Using the list_users and get_user tools, analyze churn over the last #{args["days"]} days with threshold #{args["threshold"]}."
+            }
+          }
+        ]
+      end
+    end
+
+    prompt :summarize_reports do
+      description("Summarize recent reports")
+      argument(:report_type, :string,
+        required: true,
+        description: "Type of report",
+        enum: ["sales", "inventory", "employee"]
+      )
+
+      messages fn args ->
+        report_type = Map.get(args, "report_type", "sales")
+
+        [
+          %{
+            role: :system,
+            content: %{
+              type: :text,
+              text: "You are a report analyst. Summarize the #{report_type} reports."
+            }
+          },
+          %{
+            role: :user,
+            content: %{
+              type: :text,
+              text: "Provide a concise summary of the latest #{report_type} reports."
+            }
+          }
+        ]
+      end
+    end
+
+    prompt :simple_prompt do
+      description("A simple prompt without arguments")
+
+      messages fn _args ->
+        [
+          %{
+            role: :user,
+            content: %{
+              type: :text,
+              text: "What is the weather today?"
+            }
+          }
+        ]
+      end
+    end
+
+    prompt :prompt_with_actor do
+      description("Prompt that uses the actor")
+      argument(:topic, :string, required: true, description: "Topic to analyze")
+
+      messages fn args ->
+        [
+          %{
+            role: :assistant,
+            content: %{
+              type: :text,
+              text: "Please analyze the topic: #{args["topic"]}"
+            }
+          }
+        ]
+      end
+    end
+
+  end
+
+  defmodule PromptMCP.Prompt.CrasherPrompt do
+    def name, do: "crasher_prompt"
+    def description, do: "A prompt that crashes"
+    def __mcp_component_type__, do: :prompt
+    def __scopes__, do: []
+
+    def arguments, do: []
+
+    def get_messages(_args, frame) do
+      try do
+        raise "Intentional crash for testing"
+      rescue
+        e ->
+          error = %Anubis.MCP.Error{
+            code: -32_603,
+            message: "Prompt execution error: #{Exception.message(e)}",
+            data: %{
+              error: inspect(e),
+              stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+            }
+          }
+
+          {:error, error, frame}
+      end
+    end
+  end
+
+  describe "prompt definition" do
+    test "generates prompt module" do
+      assert {:module, _} = Code.ensure_loaded(PromptMCP.Prompt.AnalyzeChurn)
+    end
+
+    test "prompt module has correct name" do
+      assert PromptMCP.Prompt.AnalyzeChurn.name() == "analyze_churn"
+    end
+
+    test "prompt module has correct component type" do
+      assert PromptMCP.Prompt.AnalyzeChurn.__mcp_component_type__() == :prompt
+    end
+
+    test "prompt module has description" do
+      assert PromptMCP.Prompt.AnalyzeChurn.description() == "Analyze user churn over a time period"
+    end
+  end
+
+  describe "arguments" do
+    test "required argument is marked as required" do
+      args = PromptMCP.Prompt.AnalyzeChurn.arguments()
+
+      days_arg = Enum.find(args, &(&1["name"] == "days"))
+      assert days_arg["required"] == true
+      assert days_arg["description"] == "Days to look back"
+    end
+
+    test "optional argument with default is not required" do
+      args = PromptMCP.Prompt.AnalyzeChurn.arguments()
+
+      threshold_arg = Enum.find(args, &(&1["name"] == "threshold"))
+      assert threshold_arg["required"] == false
+      assert threshold_arg["default"] == 0.05
+    end
+
+    test "argument with enum values includes enum list" do
+      args = PromptMCP.Prompt.SummarizeReports.arguments()
+
+      type_arg = Enum.find(args, &(&1["name"] == "report_type"))
+      assert type_arg["enum"] == ["sales", "inventory", "employee"]
+    end
+
+    test "simple prompt has no arguments" do
+      args = PromptMCP.Prompt.SimplePrompt.arguments()
+      assert args == []
+    end
+  end
+
+  describe "get_messages execution" do
+    test "returns messages with required argument" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} =
+        PromptMCP.Prompt.AnalyzeChurn.get_messages(%{"days" => "30", "threshold" => 0.1}, frame)
+
+      assert response.type == :prompt
+      assert length(response.messages) == 1
+
+      assert [%{"role" => "user", "content" => %{"type" => "text", "text" => text}}] =
+               response.messages
+
+      assert text =~ "30"
+      assert text =~ "0.1"
+    end
+
+    test "applies default value when not provided" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} =
+        PromptMCP.Prompt.AnalyzeChurn.get_messages(%{"days" => "7"}, frame)
+
+      assert response.type == :prompt
+      assert [%{"role" => "user", "content" => %{"type" => "text", "text" => text}}] =
+               response.messages
+
+      assert text =~ "7"
+      assert text =~ "0.05"
+    end
+
+    test "simple prompt with no arguments returns single message" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} = PromptMCP.Prompt.SimplePrompt.get_messages(%{}, frame)
+
+      assert response.type == :prompt
+      assert length(response.messages) == 1
+      assert [%{"role" => "user", "content" => %{"type" => "text", "text" => "What is the weather today?"}}] =
+               response.messages
+    end
+
+    test "prompt with multiple messages returns all of them" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} =
+        PromptMCP.Prompt.SummarizeReports.get_messages(%{"report_type" => "sales"}, frame)
+
+      assert response.type == :prompt
+      assert length(response.messages) == 2
+
+      assert [%{"role" => "system", "content" => %{"type" => "text", "text" => text1}},
+              %{"role" => "user", "content" => %{"type" => "text", "text" => text2}}] =
+               response.messages
+
+      assert text1 =~ "sales"
+      assert text2 =~ "sales"
+    end
+
+    test "prompt uses assistant role" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      {:reply, response, _frame} =
+        PromptMCP.Prompt.PromptWithActor.get_messages(%{"topic" => "security"}, frame)
+
+      assert [%{"role" => "assistant", "content" => %{"type" => "text", "text" => text}}] =
+               response.messages
+
+      assert text =~ "security"
+    end
+
+    test "handles nil args gracefully" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+      {:reply, response, _frame} = PromptMCP.Prompt.SimplePrompt.get_messages(nil, frame)
+      assert response.type == :prompt
+    end
+  end
+
+  describe "prompt error handling" do
+    test "handles exceptions in messages callback" do
+      frame = %Anubis.Server.Frame{assigns: %{}}
+
+      result = PromptMCP.Prompt.CrasherPrompt.get_messages(%{}, frame)
+
+      case result do
+        {:error, %Anubis.MCP.Error{code: -32_603, message: msg}, _frame} ->
+          assert msg =~ "Intentional crash for testing"
+
+        _ ->
+          flunk("Expected an error but got: #{inspect(result)}")
+      end
+    end
+  end
+
+  describe "prompt registration with MCP server" do
+    test "prompts are registered as components" do
+      components = PromptMCP.__components__(:prompt)
+      prompt_names = Enum.map(components, & &1.name)
+
+      assert "analyze_churn" in prompt_names
+      assert "summarize_reports" in prompt_names
+      assert "simple_prompt" in prompt_names
+      assert "prompt_with_actor" in prompt_names
+    end
+
+    test "prompts coexist with exposed schemas" do
+      assert {:module, _} = Code.ensure_loaded(PromptMCP.Prompt.AnalyzeChurn)
+      assert {:module, _} = Code.ensure_loaded(PromptMCP.Resource.TestUser)
+      assert {:module, _} = Code.ensure_loaded(PromptMCP.Resource.Schemas)
+    end
+  end
+
+  describe "capabilities" do
+    test "server includes prompts capability" do
+      caps = PromptMCP.server_capabilities()
+      assert Map.has_key?(caps, "prompts")
+    end
+  end
+end

--- a/test/ectomancer/prompt_test.exs
+++ b/test/ectomancer/prompt_test.exs
@@ -26,28 +26,30 @@ defmodule Ectomancer.PromptTest do
       argument(:days, :integer, required: true, description: "Days to look back")
       argument(:threshold, :float, default: 0.05, description: "Churn threshold")
 
-      messages fn args ->
+      messages(fn args ->
         [
           %{
             role: :user,
             content: %{
               type: :text,
-              text: "Using the list_users and get_user tools, analyze churn over the last #{args["days"]} days with threshold #{args["threshold"]}."
+              text:
+                "Using the list_users and get_user tools, analyze churn over the last #{args["days"]} days with threshold #{args["threshold"]}."
             }
           }
         ]
-      end
+      end)
     end
 
     prompt :summarize_reports do
       description("Summarize recent reports")
+
       argument(:report_type, :string,
         required: true,
         description: "Type of report",
         enum: ["sales", "inventory", "employee"]
       )
 
-      messages fn args ->
+      messages(fn args ->
         report_type = Map.get(args, "report_type", "sales")
 
         [
@@ -66,13 +68,13 @@ defmodule Ectomancer.PromptTest do
             }
           }
         ]
-      end
+      end)
     end
 
     prompt :simple_prompt do
       description("A simple prompt without arguments")
 
-      messages fn _args ->
+      messages(fn _args ->
         [
           %{
             role: :user,
@@ -82,14 +84,14 @@ defmodule Ectomancer.PromptTest do
             }
           }
         ]
-      end
+      end)
     end
 
     prompt :prompt_with_actor do
       description("Prompt that uses the actor")
       argument(:topic, :string, required: true, description: "Topic to analyze")
 
-      messages fn args ->
+      messages(fn args ->
         [
           %{
             role: :assistant,
@@ -99,9 +101,8 @@ defmodule Ectomancer.PromptTest do
             }
           }
         ]
-      end
+      end)
     end
-
   end
 
   defmodule PromptMCP.Prompt.CrasherPrompt do
@@ -145,7 +146,8 @@ defmodule Ectomancer.PromptTest do
     end
 
     test "prompt module has description" do
-      assert PromptMCP.Prompt.AnalyzeChurn.description() == "Analyze user churn over a time period"
+      assert PromptMCP.Prompt.AnalyzeChurn.description() ==
+               "Analyze user churn over a time period"
     end
   end
 
@@ -203,6 +205,7 @@ defmodule Ectomancer.PromptTest do
         PromptMCP.Prompt.AnalyzeChurn.get_messages(%{"days" => "7"}, frame)
 
       assert response.type == :prompt
+
       assert [%{"role" => "user", "content" => %{"type" => "text", "text" => text}}] =
                response.messages
 
@@ -217,7 +220,13 @@ defmodule Ectomancer.PromptTest do
 
       assert response.type == :prompt
       assert length(response.messages) == 1
-      assert [%{"role" => "user", "content" => %{"type" => "text", "text" => "What is the weather today?"}}] =
+
+      assert [
+               %{
+                 "role" => "user",
+                 "content" => %{"type" => "text", "text" => "What is the weather today?"}
+               }
+             ] =
                response.messages
     end
 
@@ -230,8 +239,10 @@ defmodule Ectomancer.PromptTest do
       assert response.type == :prompt
       assert length(response.messages) == 2
 
-      assert [%{"role" => "system", "content" => %{"type" => "text", "text" => text1}},
-              %{"role" => "user", "content" => %{"type" => "text", "text" => text2}}] =
+      assert [
+               %{"role" => "system", "content" => %{"type" => "text", "text" => text1}},
+               %{"role" => "user", "content" => %{"type" => "text", "text" => text2}}
+             ] =
                response.messages
 
       assert text1 =~ "sales"
@@ -313,10 +324,12 @@ defmodule Ectomancer.PromptTest do
       assert threshold_arg["default"] == 0.05
 
       frame = %Anubis.Server.Frame{assigns: %{}}
-      {:reply, response, _frame} = churn.handler.get_messages(
-        %{"days" => "30", "threshold" => 0.1},
-        frame
-      )
+
+      {:reply, response, _frame} =
+        churn.handler.get_messages(
+          %{"days" => "30", "threshold" => 0.1},
+          frame
+        )
 
       assert response.type == :prompt
       assert [%{"role" => "user", "content" => %{"text" => text}}] = response.messages
@@ -334,10 +347,12 @@ defmodule Ectomancer.PromptTest do
       assert type_arg["enum"] == ["sales", "inventory", "employee"]
 
       frame = %Anubis.Server.Frame{assigns: %{}}
-      {:reply, response, _frame} = summary.handler.get_messages(
-        %{"report_type" => "inventory"},
-        frame
-      )
+
+      {:reply, response, _frame} =
+        summary.handler.get_messages(
+          %{"report_type" => "inventory"},
+          frame
+        )
 
       assert response.type == :prompt
       assert length(response.messages) == 2

--- a/test/ectomancer/prompt_test.exs
+++ b/test/ectomancer/prompt_test.exs
@@ -297,4 +297,52 @@ defmodule Ectomancer.PromptTest do
       assert Map.has_key?(caps, "prompts")
     end
   end
+
+  describe "smoke test: prompts/get protocol path" do
+    test "resolves, validates, and executes a prompt through the component registry" do
+      prompts = PromptMCP.__components__(:prompt)
+
+      churn = Enum.find(prompts, &(&1.name == "analyze_churn"))
+      assert churn
+      assert churn.description == "Analyze user churn over a time period"
+
+      days_arg = Enum.find(churn.arguments, &(&1["name"] == "days"))
+      assert days_arg["required"] == true
+
+      threshold_arg = Enum.find(churn.arguments, &(&1["name"] == "threshold"))
+      assert threshold_arg["default"] == 0.05
+
+      frame = %Anubis.Server.Frame{assigns: %{}}
+      {:reply, response, _frame} = churn.handler.get_messages(
+        %{"days" => "30", "threshold" => 0.1},
+        frame
+      )
+
+      assert response.type == :prompt
+      assert [%{"role" => "user", "content" => %{"text" => text}}] = response.messages
+      assert text =~ "30"
+      assert text =~ "0.1"
+    end
+
+    test "prompt with enum argument validates through the registry" do
+      prompts = PromptMCP.__components__(:prompt)
+
+      summary = Enum.find(prompts, &(&1.name == "summarize_reports"))
+      assert summary
+
+      type_arg = Enum.find(summary.arguments, &(&1["name"] == "report_type"))
+      assert type_arg["enum"] == ["sales", "inventory", "employee"]
+
+      frame = %Anubis.Server.Frame{assigns: %{}}
+      {:reply, response, _frame} = summary.handler.get_messages(
+        %{"report_type" => "inventory"},
+        frame
+      )
+
+      assert response.type == :prompt
+      assert length(response.messages) == 2
+      assert Enum.any?(response.messages, &(&1["role"] == "system"))
+      assert Enum.any?(response.messages, &(&1["role"] == "user"))
+    end
+  end
 end

--- a/test/ectomancer/prompt_test.exs
+++ b/test/ectomancer/prompt_test.exs
@@ -114,6 +114,7 @@ defmodule Ectomancer.PromptTest do
     def arguments, do: []
 
     def get_messages(_args, frame) do
+      # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
       try do
         raise "Intentional crash for testing"
       rescue


### PR DESCRIPTION
## Summary

Adds a `prompt/2` macro for defining MCP prompt templates, enabling structured, parameterized prompts for LLM clients.

Closes #104

## Changes

### `lib/ectomancer/prompt.ex` (new)
- `prompt/2` DSL macro following the same pattern as `Ectomancer.Tool`
- `description/1` — human-readable prompt description  
- `argument/4` — typed arguments with `required`, `default`, `description`, `enum` support
- `messages/1` — callback `fn args -> [%{role: ..., content: ...}] end`
- Generated modules implement `__mcp_component_type__/0`, `__scopes__/0`, `name/0`, `arguments/0`, `get_messages/2`
- Error handling with `try/rescue` in generated `get_messages/2`

### `lib/ectomancer.ex`
- Added `:prompts` to Anubis capabilities
- Imported `prompt/2` from `Ectomancer.Prompt`

### `test/ectomancer/prompt_test.exs` (new, 18 tests)
- Prompt definition, component type, description
- Argument validation (required, default, enum)
- Message execution with string-keyed args
- Multiple messages, roles (user/assistant/system)
- Error handling for crashing callbacks
- Component registration and coexistence with exposed schemas
- Server capabilities include prompts

### `test/ectomancer/plug_integration_test.exs`
- Wrapped WebSocket connect test with `ExUnit.CaptureLog` to suppress `Logger.error` in CI

## Usage

```elixir
defmodule MyApp.MCP do
  use Ectomancer, name: "my-app", version: "1.0.0"

  prompt :analyze_churn do
    description "Analyze user churn over a time period"
    argument :days, :integer, required: true, description: "Days to look back"
    argument :threshold, :float, default: 0.05

    messages fn args ->
      [%{role: :user, content: %{type: :text, text: "Analyze churn over #{args["days"]} days..."}}]
    end
  end
end
```