### PR TITLE
Release v1.6.0: Batch operations support

### DIFF
--- a/.opencode/command/phx-review.md
+++ b/.opencode/command/phx-review.md
@@ -1,0 +1,6 @@
+---
+description: Review Elixir/Phoenix code with parallel specialist agents
+skill: phx-review
+---
+
+$ARGUMENTS

--- a/.opencode/skills/changelog/SKILL.md
+++ b/.opencode/skills/changelog/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: changelog
+description: Generate or update CHANGELOG.md entries from git log for Hex.pm releases. Extracts what changed, categorizes by type (Added/Changed/Fixed/Deprecated/Removed/Security), detects breaking changes, and enriches entries with examples, configuration snippets, and upgrade notes.
+---
+
+# Generate Changelog for Hex.pm Release
+
+Generate a complete changelog entry by analyzing commits since the last tag, researching each feature's implementation, and writing detailed entries suitable for Hex.pm publication.
+
+## Workflow
+
+### Step 1: Discover Commits Since Last Tag
+
+```bash
+git log --oneline --format="%h %s" $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD
+git log --oneline $(git describe --tags --abbrev=0)..HEAD --format="%s"
+```
+
+Group commits by type:
+- `feat:` / `feature:` → **Added**
+- `fix:` → **Fixed**
+- `refactor:` → **Changed** (only if user-facing)
+- `docs:` → skip (unless docs-only release)
+- BREAKING / `!:` → **Breaking change** / prefix with `### ⚠️ Breaking Changes`
+
+### Step 2: Diff Against Existing Unreleased Section
+
+Read `CHANGELOG.md` Unreleased section. If it already has entries, cross-reference with the git log to:
+- Remove duplicates (already in CHANGELOG)
+- Identify commits missing from CHANGELOG
+- Identify commits that are internal-only (refactors, test-only, tooling) — skip these unless the change is architecturally significant
+
+### Step 3: Research Each New Feature
+
+For each feature not yet documented, use the `task` tool with `subagent_type: "explore"` to research the implementation. Request:
+
+1. The macro/function signature
+2. Configuration options and defaults
+3. How it works (3 sentence max)
+4. Example usage from README or tests
+5. Whether it has authorization/scope/soft-delete integration
+6. Whether it changes any existing behavior (breaking?)
+7. The return format
+
+### Step 4: Detect Breaking Changes
+
+Check each commit and feature for:
+- Modified existing macros or functions (not additive)
+- Changed default behavior
+- Removed options or deprecations
+- Changed return types
+- Updated minimum dependency versions
+
+If any are found, add a `### ⚠️ Breaking Changes` section at the top of the release entry.
+
+### Step 5: Write the Changelog Entry
+
+Format per [Keep a Changelog](https://keepachangelog.com/en/1.0.0/):
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- **Feature name** — brief description (#PR)
+  Longer explanation with bullet points.
+
+  Configuration example (if applicable):
+  ```elixir
+  expose MyApp.Accounts.User,
+    actions: [:feature],
+    feature_option: :value
+  ```
+
+  Return format:
+  ```elixir
+  {:ok, %{...}}
+  ```
+
+### Changed
+- Only if user-facing behavior changed
+
+### Fixed
+- Bug fixes with issue/PR references
+
+### Deprecated / Removed / Security
+- As needed
+```
+
+**Enrichment rules:**
+- Each top-level bullet must have: feature name bolded, PR number, and at least one sentence of explanation
+- Include a ` ```elixir ``` ` config snippet if the feature has configuration options
+- Include the return/response format if it's a new tool or function
+- Mention integration with existing systems (auth, scoping, soft-delete, telemetry)
+- If there's a README section, reference it by line
+- End the entry with `**No breaking changes**` or the breaking changes summary
+
+### Step 6: Update CHANGELOG.md
+
+1. Move content from `## [Unreleased]` into the new release section
+2. Add the new `[X.Y.Z]` tag link at the bottom
+3. Update `[Unreleased]` link to point to `compare/vX.Y.Z...HEAD`
+4. Update date to today
+
+### Step 7: Verify
+
+Read the final CHANGELOG.md, confirm:
+- All commits since last tag are accounted for
+- No duplicates between Unreleased and new section
+- Examples are syntactically valid Elixir
+- PR numbers are present
+- Date is today
+- Tag links at bottom are updated
+
+## Examples
+
+### Good entry (batch operations):
+
+```markdown
+### Added
+- **Batch operations** — three new transactional actions: `batch_create`, `batch_update`, `batch_destroy` (#109)
+
+  Enable per schema:
+  ```elixir
+  expose MyApp.Accounts.User,
+    actions: [:batch_create, :batch_update, :batch_destroy],
+    batch_size: 200
+  ```
+
+  All three run inside a single `repo.transaction`. Invalid records are collected without aborting valid ones. Returns `%{succeeded: [...], failed: [...], total: N}`.
+
+  `batch_size` (default: `100`) is enforced before any DB interaction. Exceeding it returns MCP error code `-32602`. Full authorization, scope, and soft-delete support.
+```
+
+### Weak entry (too terse — don't do this):
+
+```markdown
+### Added
+- Batch operations: batch_create, batch_update, batch_destroy (#109)
+```
+
+## Project-Specific Conventions (Ectomancer)
+
+- Optional dependencies (`phoenix`, `ecto`, `oban`) are loaded only if parent app uses them — never mention them as required
+- All features should note authorization/scope/soft-delete integration where applicable
+- Tool naming follows `{action}_{resource}` pattern (e.g., `batch_create_users`)
+- Default values are always documented (e.g., `batch_size: 100`)
+- If the feature changes nothing about existing behavior, explicitly say "No breaking changes"

--- a/.opencode/skills/phx-review/SKILL.md
+++ b/.opencode/skills/phx-review/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: phx-review
+description: Review Elixir/Phoenix code with parallel specialist agents — tests, security, Ecto, LiveView, Oban. Use after implementation to catch bugs and anti-patterns before committing.
+---
+
+# Review Elixir/Phoenix Code
+
+Review code by spawning parallel specialist agents. Find and explain issues — do NOT create tasks or fix anything.
+
+## Usage
+
+Invoke with: `phx-review [focus]`
+
+**Focus areas:**
+- `phx-review` or `phx-review all` — Auto-detect and review all areas
+- `phx-review test` — Review test files only
+- `phx-review security` — Run security audit only
+- `phx-review oban` — Review Oban workers only
+- `phx-review deploy` — Validate deployment config
+- `phx-review iron-laws` — Check Iron Law violations only
+
+**Alternative inputs:**
+- Linear issue ID (e.g. `ENA-8931`) — Force specific Linear issue
+- GitHub issue (e.g. `#42`) — Force specific GitHub issue
+- Plan/spec file path — Force specific plan or spec file
+- `--no-requirements` — Skip requirements coverage check
+- `--codex` — Add Codex CLI as cross-model reviewer
+
+## Workflow
+
+### Step 1: Identify Changed Files and Prepare Directories
+
+**CRITICAL**: Create output directories BEFORE spawning agents — agents cannot create directories and writes will fail.
+
+1. Determine SLUG via Glob on `.claude/plans/*/` (default: `"review"`)
+2. Run `mkdir -p ".claude/plans/${SLUG}/reviews" ".claude/plans/${SLUG}/summaries" .claude/reviews`
+3. Run `git diff --name-only HEAD~5` and `git diff --name-only main`
+4. Save the diff base for pre-existing detection in Step 3b
+
+### Step 1b: Load Plan Context and Prior Reviews
+
+- Read `.claude/plans/${SLUG}/scratchpad.md` for planning decisions and rationale
+- Pass relevant decisions to agents as WHY-context (eliminates session archaeology)
+- Check `.claude/plans/${SLUG}/reviews/` for prior output; if present, include a consolidated summary as "PRIOR FINDINGS" with: "Focus on NEW issues. Mark still-present issues as PERSISTENT."
+
+### Step 1c: Detect Requirements Source (skip on `--no-requirements`)
+
+Find a task/spec whose requirements should be cross-checked against the diff. Priority order (stop at first match): explicit arg → conversation context → branch regex → commit subjects → latest plan → none.
+
+Fetch the detected source into `.claude/plans/${SLUG}/reviews/.requirements-input.md` (Linear via MCP, GitHub via `gh issue view`, file via Read). Record `REQ_SOURCE` label (e.g. `"Linear ENA-8931"`) for the verifier heading. On fetch failure, set `SOURCE_STATUS=FETCH_FAILED` and continue — verifier will emit `NOT AVAILABLE` rather than block the review.
+
+### Step 2: Spawn Review Agents (MANDATORY)
+
+**NEVER** spawn the same agent role twice per review. One pass per role.
+**NEVER** analyze code yourself — use the Task tool only. Zero agents = failure.
+
+1. Create a Task per agent via the `task` tool with `mode: "subagent"` and `run_in_background: true`
+2. For `phx-review` or `phx-review all`: select agents dynamically per focus area
+3. For focused reviews (`test|security|oban|deploy|iron-laws`): spawn only the matching specialist
+4. **If Step 1c succeeded** (REQ_SOURCE non-empty and `--no-requirements` not passed): add an `elixir-phoenix:requirements-verifier` agent to the same parallel batch. Pass these prompt inputs: `REQUIREMENTS_TEXT` (content of `.requirements-input.md`), `REQUIREMENTS_SOURCE` (REQ_SOURCE label), `DIFF_FILES` (git diff --name-only output), `SOURCE_STATUS` (only if FETCH_FAILED), `output_file: .claude/plans/{slug}/reviews/requirements.md`
+5. Spawn in ONE message with multiple parallel Task calls
+6. **MANDATORY**: pass explicit `output_file` per-agent
+7. Include the CRITICAL prompt block: write by turn ~12, chat body ≤300 words
+8. Scope every agent to the diff: pass `git diff --name-only` output with "Focus on NEW code. Pre-existing: one-line `{file}:{line} — {brief}`. Do NOT deep-analyze unchanged files."
+9. **With `--codex`**: add `elixir-phoenix:codex-reviewer` to the same batch. Missing CLI degrades to SKIPPED.
+
+### Step 3: Collect and Compress Findings
+
+Wait for ALL agents to complete. **Do NOT report status until every agent completes.** Mark each task `completed` via status update as it finishes.
+
+**Missing file fallback** — after each agent finishes, verify its expected `output_file` exists. If missing (turn exhaustion, error):
+
+1. Append to `.claude/plans/{slug}/scratchpad.md`: `[HH:MM] WARN: {agent} did not write {expected_path} — extracting from message`
+2. Parse findings from the agent's return message as fallback
+3. Mark the section in the final review with `⚠️ EXTRACTED FROM AGENT MESSAGE (see scratchpad)` — never silent
+
+**Verification-runner fallback** — if it times out, run directly:
+`mix compile --warnings-as-errors && mix format --check-formatted $(git diff --name-only HEAD~5 | grep '\.exs\?$' | tr '\n' ' ') && mix credo --strict && mix test`
+
+**Context supervision** — for 4+ agents, spawn `elixir-phoenix:context-supervisor`:
+
+```
+Prompt: "Compress review agent output.
+  input_dir: .claude/plans/{slug}/reviews
+  output_dir: .claude/plans/{slug}/summaries
+  output_file: review-consolidated.md
+  priority_instructions: BLOCKERs and WARNINGs: KEEP ALL.
+    SUGGESTIONs: COMPRESS similar ones into groups.
+    Deconfliction: when iron-law-judge and elixir-reviewer
+    flag same code, keep iron-law-judge finding."
+```
+
+Skip the supervisor for focused (1-agent) reviews — read output directly.
+
+### Step 3b: Filter Findings (Anti-Noise)
+
+Before writing the review, apply these overriding filters to each finding:
+
+1. Would a senior Elixir dev dismiss this as noise?
+2. Does the finding add complexity exceeding the problem's complexity?
+3. Are any findings duplicates reworded by different agents?
+4. Does the finding affect code actually changed in this diff?
+5. Is the finding on unchanged code (not in diff)? → Mark PRE-EXISTING
+6. Flagged by both a Claude agent AND `[codex]`? → mark HIGH CONFIDENCE
+
+Demote or remove findings that fail filters 1-4. Mark pre-existing per filter 5.
+
+### Step 4: Generate Review Summary
+
+Read consolidated/agent output. Write to `.claude/plans/{slug}/reviews/{feature}-review.md` with verdict: `PASS | PASS WITH WARNINGS | REQUIRES CHANGES | BLOCKED`.
+
+**Requirements Coverage in verdict**: if the verifier ran, read its summary line and fold into the verdict:
+
+- Any `UNMET` → escalate to `REQUIRES CHANGES` (even if code-quality PASS)
+- Any `PARTIAL` (no UNMET) → downgrade PASS → `PASS WITH WARNINGS`
+- `NOT AVAILABLE` / all `MET` / `UNCLEAR` only → no verdict change
+
+Insert the verifier's `## Requirements Coverage` block into the review document **before** the per-agent findings so it's the first thing the user sees.
+
+### Step 5: Present Findings and Ask User
+
+**STOP and present the review.** Do NOT create tasks or fix anything.
+
+**On BLOCKED or REQUIRES CHANGES**: Show finding count by severity, then offer:
+- `/phx:triage` (recommended)
+- `/phx:plan .claude/plans/{slug}/reviews/{feature}-review.md` (converts findings into a follow-up plan — pass the review file path, not a re-description)
+- Fix directly (when codex ran)
+- "I'll handle it myself"
+
+**On PASS / PASS WITH WARNINGS**: Suggest `/phx:compound`, `/phx:learn-from-fix`.
+
+**Convention extraction**: After presenting findings, offer: "Any findings to suppress or enforce as conventions?"
+
+## Iron Laws
+
+1. **Review is READ-ONLY** — Find and explain, never fix
+2. **NEVER auto-fix after review** — Always ask the user first
+3. **Always offer both paths**: `/phx:plan` and `/phx:work`
+4. **Research before claiming** — Agents MUST research before making claims about CI/CD or external services
+
+## Integration
+
+`/phx:plan` → `/phx:work` → `/phx:review` (YOU ARE HERE) → Blocked? `/phx:triage` or `/phx:plan` | Pass? `/phx:compound`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-20
+
 ### Added
-- Batch operations: `batch_create`, `batch_update`, `batch_destroy` actions (#109)
-  - `batch_create` — insert multiple records in a single transaction
-  - `batch_update` — update multiple records (by primary key) atomically
-  - `batch_destroy` — delete/soft-delete multiple records in one call
-  - Partial failure reporting: returns `%{succeeded: [...], failed: [...]}` per batch
-  - Configurable `:batch_size` option (default: 100) per exposed schema
-  - Full authorization, scope, and soft-delete support for all batch actions
+- **MCP Prompts** — `prompt/2` macro for structured, parameterized prompt templates with argument validation (#122)
+
+  Define prompts alongside your tools:
+  ```elixir
+  prompt :analyze_churn do
+    description "Analyze user churn risk"
+    argument :cohort, :string, required: true, description: "User cohort"
+    messages fn args ->
+      [%{role: :user, content: %{type: :text, text: "Analyze churn for #{args["cohort"]}"}}]
+    end
+  end
+  ```
+
+  Supports `:string`, `:integer`, `:float`, `:boolean`, `:list`, and `:map` argument types with `required`, `description`, `default`, and `enum` options. Arguments are validated by Anubis before the messages callback runs. Registered automatically as MCP prompts — visible via `prompts/list` and callable via `prompts/get`.
+
+- **Upsert operations** — `:upsert` action for insert-or-update workflows with configurable conflict target and `on_conflict` control (#117)
+
+  ```elixir
+  expose MyApp.Products.Product,
+    actions: [:upsert],
+    conflict_target: :sku,
+    on_conflict: :replace_all
+  ```
+
+  Returns `{:ok, {record, :inserted | :updated}}`. Supports composite conflict targets (`conflict_target: [:org_id, :sku]`) and selective `on_conflict: [set: [:name, :avatar_url]]`. Automatically restores soft-deleted records. `conflict_target` is required at compile time.
+
+- **Batch operations** — `batch_create`, `batch_update`, `batch_destroy` for transactional multi-record operations (#116)
+
+  ```elixir
+  expose MyApp.Accounts.User,
+    actions: [:batch_create, :batch_update, :batch_destroy],
+    batch_size: 200
+  ```
+
+  Each runs inside a single `repo.transaction` with individual try/rescue per item — invalid records are collected without aborting valid ones. Returns `%{succeeded: [...], failed: [...], total: N}`. Configurable `:batch_size` (default: `100`) enforced before any DB interaction. Full authorization, scope, and soft-delete support.
+
+- **SSE and WebSocket transport support** — three transport options for MCP protocol serving (#120)
+
+  | Transport | Status | Route |
+  |---|---|---|
+  | **Streamable HTTP** (MCP 2025-03-26) | **Default** | `forward "/", Ectomancer.Plug` |
+  | **SSE** (MCP 2024-11-05) | Deprecated | `get "/sse"` + `post "/sse"` |
+  | **WebSocket** | Available | `socket "/mcp/ws", Ectomancer.Plug.WebSocket` |
+
+  Streamable HTTP uses a single endpoint with session header (`mcp-session-id`) and streaming responses. WebSocket supports actor extraction via query params or `x_headers`. Use `Ectomancer.child_spec/2` for multi-transport supervision.
+
+- **Igniter installer** — `mix igniter.install ectomancer` for fully automated setup (#119)
+
+  Automatically: adds dependency, discovers schemas with interactive selection, generates `lib/my_app/mcp.ex`, patches `config/config.exs`, injects `forward` route into the router, adds `Anubis.Server.Supervisor` to the supervision tree via AST patching, and prompts for transport selection. Idempotent — safe to re-run.
+
+- **Per-action authorization for Oban bridge** — `expose_oban_jobs` now supports granular authorize rules per action (#121)
+
+  ```elixir
+  expose_oban_jobs authorize: [
+    all: fn actor, _action -> actor.role == :admin end,
+    list_queues: :public,
+    cancel_job: fn actor, _action -> actor.role == :admin end
+  ]
+  ```
+
+  Supports function, module, `:none`/`:public`, or keyword lists with `:all` fallback. Unlisted actions fall through to the global authorization from `use Ectomancer`.
+
+- **Custom MCP Resources** — `resource/2` macro for defining custom resources alongside auto-generated schema resources (v1.4.0 — listed here for discoverability)
+- **Rate limiting** — configurable token bucket per tool or globally (v1.4.0)
+
+### Changed
+- Internal codebase refactored into focused submodules with reduced duplication (#118) — no user-facing API changes
+
+### No breaking changes
 
 ## [1.5.0] - 2026-07-17
 
@@ -323,7 +387,8 @@ expose MyApp.Blog.Post, readonly: true
 - Row limits to prevent memory exhaustion (100 records default)
 - Proper error messages without exposing internal details
 
-[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/GustavoZiaugra/ectomancer/compare/v1.3.0...v1.3.1

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add `ectomancer` to your dependencies:
 ```elixir
 def deps do
   [
-    {:ectomancer, "~> 1.5"}
+    {:ectomancer, "~> 1.6"}
   ]
 end
 ```
@@ -517,7 +517,7 @@ mix test
 
 Zero compiler warnings, full Credo and Dialyzer compliance.
 
-Current version: **1.5.0**
+Current version: **1.6.0**
 
 ## License
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Ectomancer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/GustavoZiaugra/ectomancer"
-  @version "1.5.0"
+  @version "1.6.0"
 
   def project do
     [


### PR DESCRIPTION
## v1.6.0

### Added
- Batch operations: `batch_create`, `batch_update`, `batch_destroy` actions (#109)
  - Insert, update, or delete multiple records in a single transaction
  - Partial failure reporting with `%{succeeded: [...], failed: [...]}`
  - Configurable `:batch_size` option (default: 100) per exposed schema
  - Full authorization, scope, and soft-delete support