### PR TITLE
fix: silence ExDoc warnings for hidden modules/functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Igniter installer** — `mix igniter.install ectomancer` for fully automated setup (#119)
 
-  Automatically: adds dependency, discovers schemas with interactive selection, generates `lib/my_app/mcp.ex`, patches `config/config.exs`, injects `forward` route into the router, adds `Anubis.Server.Supervisor` to the supervision tree via AST patching, and prompts for transport selection. Idempotent — safe to re-run.
+  Automatically: adds dependency, discovers schemas with interactive selection, generates `lib/my_app/mcp.ex`, patches `config/config.exs`, injects `forward` route into the router, adds a supervisor to the supervision tree via AST patching, and prompts for transport selection. Idempotent — safe to re-run.
 
 - **Per-action authorization for Oban bridge** — `expose_oban_jobs` now supports granular authorize rules per action (#121)
 

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -802,10 +802,15 @@ if Code.ensure_loaded?(Ecto) do
       repo.update(changeset)
     end
 
+    @doc false
     defdelegate extract_meta_params(params), to: Filtering
+    @doc false
     defdelegate parse_filter_key(key), to: Filtering
+    @doc false
     defdelegate sanitize_like(value), to: Filtering
+    @doc false
     defdelegate parse_order_dir(dir), to: Filtering
+    @doc false
     defdelegate parse_int(val), to: Filtering
 
     defp normalize_params(params, schema_module) do


### PR DESCRIPTION
## Changes

- **`lib/ectomancer/repo.ex`**: Added `@doc false` to `defdelegate` calls that delegate to the hidden `Ectomancer.Repo.Filtering` module, preventing ExDoc warnings about referencing hidden functions.
- **`CHANGELOG.md`**: Removed backticks around `Anubis.Server.Supervisor` reference (line 61) which was being interpreted as a module reference to a hidden module. Changed to plain text "a supervisor".