### PR TITLE
Fix pluralization in expose.ex to use Plurality library (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Tool name pluralization** — `singularize_resource/1` now uses `Plurality` for noun inflection and keeps already-singular words ending in "s" intact. Tool names for `status`, `analysis`, `business`, `series`, `class`, `address`, and `news` are no longer truncated (`get_status` instead of `get_statu`, etc.) (#128)
+
 ## [1.6.0] - 2026-07-20
 
 ### Added

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -647,7 +647,11 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp singularize_resource(name) when is_binary(name) do
-      Plurality.singularize(name)
+      if Plurality.singular?(name) do
+        name
+      else
+        Plurality.singularize(name)
+      end
     end
   end
 else

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -647,11 +647,7 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp singularize_resource(name) when is_binary(name) do
-      if String.ends_with?(name, "s") do
-        String.slice(name, 0..-2//1)
-      else
-        name
-      end
+      Plurality.singularize(name)
     end
   end
 else

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,9 @@ defmodule Ectomancer.MixProject do
       # JSON handling
       {:jason, "~> 1.4"},
 
+      # Noun inflection (pluralize/singularize) for tool name generation
+      {:plurality, "~> 0.3"},
+
       # Optional dependencies (only loaded if parent app uses them)
       {:phoenix, ">= 1.7.0", optional: true},
       {:ecto, "~> 3.12", optional: true},
@@ -92,7 +95,6 @@ defmodule Ectomancer.MixProject do
       # Development and testing
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
-      {:plurality, "~> 0.2"},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
 
       # Database testing

--- a/test/ectomancer/pluralization_test.exs
+++ b/test/ectomancer/pluralization_test.exs
@@ -1,0 +1,113 @@
+defmodule Ectomancer.PluralizationTest do
+  use ExUnit.Case
+
+  alias Ectomancer.PluralizationTest.TestMCP.Tool.{
+    GetAddress,
+    GetAnalysis,
+    GetBusiness,
+    GetClass,
+    GetNews,
+    GetSeries,
+    GetStatus,
+    GetUser,
+    LegacyGetStatus
+  }
+
+  defmodule Status do
+    use Ecto.Schema
+
+    schema "statuses" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule Analysis do
+    use Ecto.Schema
+
+    schema "analyses" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule Business do
+    use Ecto.Schema
+
+    schema "businesses" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule Series do
+    use Ecto.Schema
+
+    schema "series" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule Class do
+    use Ecto.Schema
+
+    schema "classes" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule Address do
+    use Ecto.Schema
+
+    schema "addresses" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule News do
+    use Ecto.Schema
+
+    schema "news" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule Users do
+    use Ecto.Schema
+
+    schema "users" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule TestMCP do
+    use Ectomancer, name: "pluralization-test-mcp", version: "1.0.0"
+
+    expose(Status, actions: [:get])
+    expose(Analysis, actions: [:get])
+    expose(Business, actions: [:get])
+    expose(Series, actions: [:get])
+    expose(Class, actions: [:get])
+    expose(Address, actions: [:get])
+    expose(News, actions: [:get])
+    expose(Users, actions: [:get])
+    expose(Status, as: :statuses, namespace: :legacy, actions: [:get])
+  end
+
+  describe "tool name singularization" do
+    test "keeps already-singular words ending in 's' intact" do
+      assert GetStatus.name() == "get_status"
+      assert GetAnalysis.name() == "get_analysis"
+      assert GetBusiness.name() == "get_business"
+      assert GetSeries.name() == "get_series"
+      assert GetClass.name() == "get_class"
+      assert GetAddress.name() == "get_address"
+      assert GetNews.name() == "get_news"
+    end
+
+    test "singularizes genuine plurals" do
+      assert GetUser.name() == "get_user"
+    end
+
+    test "singularizes plural resource names from the :as option" do
+      assert LegacyGetStatus.name() == "legacy_get_status"
+    end
+  end
+end


### PR DESCRIPTION
Replace naive s-strip algorithm in `singularize_resource/1` with `Plurality` inflection.

**Fixed tool names** (were truncated by the old s-strip):
- `business` → `business` (was `busines`)
- `class` → `class` (was `clas`)
- `address` → `address` (was `addres`)
- `series` → `series` (was `serie`)
- `news` → `news` (was `new`)
- `status` → `status` (was `statu`)
- `analysis` → `analysis` (was `analysi`)

**How it works:** `singularize_resource/1` returns the name unchanged when `Plurality.singular?/1` says it's already singular (covers `-ss`, `-us`, `-is`, uncountable words), and only calls `Plurality.singularize/1` for genuine plurals (`users` → `user`, `categories` → `category`). This was verified against the locked dependency (plurality 0.3.0) — a plain `Plurality.singularize/1` call alone still returns `statu`/`analysi` for `status`/`analysis`.

**Changes:**
- `lib/ectomancer/expose.ex` — guard with `Plurality.singular?/1` before singularizing
- `mix.exs` — bump `plurality` constraint to `~> 0.3` and move it under runtime deps
- `test/ectomancer/pluralization_test.exs` — new unit tests for tool name generation (status, analysis, business, series, class, address, news, users, `as:` plural option)
- `CHANGELOG.md` — Fixed entry under Unreleased

**Verification:** 786 tests pass, 0 Credo issues.