### PR TITLE
fix: link nested child records to parent FK correctly

### DIFF
--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -981,12 +981,14 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp insert_many_children(repo, schema_module, record, items, assoc) do
-      fk = child_fk(schema_module, record, assoc)
-      writable = child_writable_fields(schema_module, fk)
+      child_fk = child_fk(schema_module, record, assoc)
+      fk_field = if child_fk, do: elem(child_fk, 0)
+      writable = child_writable_fields(schema_module, fk_field)
 
       Enum.each(items, fn child_attrs ->
         cast_child = normalize_params(child_attrs, schema_module)
-        child = build_child(struct(schema_module, cast_child), record, fk)
+        cast_child = link_child(cast_child, record, child_fk)
+        child = struct(schema_module, cast_child)
         child_changeset = changeset_for(schema_module, child, cast_child, writable)
 
         case repo.insert(child_changeset) do
@@ -997,10 +999,12 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defp insert_one_child(repo, schema_module, record, single, assoc) do
-      fk = child_fk(schema_module, record, assoc)
-      writable = child_writable_fields(schema_module, fk)
+      child_fk = child_fk(schema_module, record, assoc)
+      fk_field = if child_fk, do: elem(child_fk, 0)
+      writable = child_writable_fields(schema_module, fk_field)
       cast_child = normalize_params(single, schema_module)
-      child = build_child(struct(schema_module, cast_child), record, fk)
+      cast_child = link_child(cast_child, record, child_fk)
+      child = struct(schema_module, cast_child)
       child_changeset = changeset_for(schema_module, child, cast_child, writable)
 
       case repo.insert(child_changeset) do
@@ -1009,7 +1013,7 @@ if Code.ensure_loaded?(Ecto) do
       end
     end
 
-    defp child_fk(schema_module, record, assoc) do
+    defp child_fk(schema_module, record, _assoc) do
       schema_module.__schema__(:associations)
       |> Enum.find_value(fn name ->
         a = schema_module.__schema__(:association, name)
@@ -1017,7 +1021,8 @@ if Code.ensure_loaded?(Ecto) do
       end)
       |> case do
         nil -> nil
-        child_assoc -> child_assoc.related_key
+        # {child FK field, parent referenced PK field}
+        child_assoc -> {child_assoc.owner_key, child_assoc.related_key}
       end
     end
 
@@ -1027,9 +1032,15 @@ if Code.ensure_loaded?(Ecto) do
       |> Enum.reject(&is_nil/1)
     end
 
-    defp build_child(child, record, fk) do
-      if fk && record.id, do: Map.put(child, fk, record.id), else: child
+    defp link_child(attrs, record, {fk, pk}) do
+      if value = Map.get(record, pk) do
+        Map.put(attrs, fk, value)
+      else
+        attrs
+      end
     end
+
+    defp link_child(attrs, _record, nil), do: attrs
 
     @doc """
     Validates dynamic include requests against allowed preloadable associations.

--- a/test/ectomancer/repo_test.exs
+++ b/test/ectomancer/repo_test.exs
@@ -957,12 +957,45 @@ defmodule Ectomancer.RepoTest do
       end
     end
 
+    defmodule CustomKeyParent do
+      use Ecto.Schema
+
+      @primary_key {:code, :binary_id, autogenerate: true}
+      schema "custom_key_parents" do
+        field(:name, :string)
+        has_many(:children, Ectomancer.RepoTest.CustomKeyChild,
+          foreign_key: :parent_code,
+          references: :code
+        )
+
+        timestamps()
+      end
+    end
+
+    defmodule CustomKeyChild do
+      use Ecto.Schema
+
+      schema "custom_key_children" do
+        field(:name, :string)
+
+        belongs_to(:parent, Ectomancer.RepoTest.CustomKeyParent,
+          foreign_key: :parent_code,
+          references: :code,
+          type: :binary_id
+        )
+
+        timestamps()
+      end
+    end
+
     setup do
       Sandbox.checkout(Ectomancer.TestRepo)
       Application.put_env(:ectomancer, :repo, Ectomancer.TestRepo)
       Ectomancer.DataCase.create_table_for_schema!(AssocParent)
       Ectomancer.DataCase.create_table_for_schema!(AssocChild)
       Ectomancer.DataCase.create_table_for_schema!(AssocProfile)
+      Ectomancer.DataCase.create_table_for_schema!(CustomKeyParent)
+      Ectomancer.DataCase.create_table_for_schema!(CustomKeyChild)
 
       on_exit(fn ->
         Application.delete_env(:ectomancer, :repo)
@@ -976,7 +1009,7 @@ defmodule Ectomancer.RepoTest do
       assert parent.name == "Solo"
     end
 
-    test "create with has_many children succeeds" do
+    test "create with has_many children succeeds and links children to parent" do
       {:ok, parent} =
         Repo.create(AssocParent, %{name: "Parent", children: [%{name: "Child1"}]},
           associations: [
@@ -986,9 +1019,14 @@ defmodule Ectomancer.RepoTest do
 
       assert parent.name == "Parent"
       assert parent.id
+
+      {:ok, children} = Repo.list(AssocChild, %{})
+      assert [child] = children
+      assert child.name == "Child1"
+      assert child.parent_id == parent.id
     end
 
-    test "create with has_one profile succeeds" do
+    test "create with has_one profile succeeds and links profile to parent" do
       {:ok, parent} =
         Repo.create(AssocParent, %{name: "Parent", profile: %{bio: "Bio"}},
           associations: [
@@ -997,6 +1035,29 @@ defmodule Ectomancer.RepoTest do
         )
 
       assert parent.name == "Parent"
+
+      {:ok, profiles} = Repo.list(AssocProfile, %{})
+      assert [profile] = profiles
+      assert profile.bio == "Bio"
+      assert profile.parent_id == parent.id
+    end
+
+    test "create with has_many children works with custom primary key" do
+      {:ok, parent} =
+        Repo.create(
+          CustomKeyParent,
+          %{name: "Parent", children: [%{name: "Kid"}]},
+          associations: [
+            %{field: :children, cardinality: :many, related: CustomKeyChild, type: :has_many}
+          ]
+        )
+
+      assert parent.code
+
+      {:ok, children} = Repo.list(CustomKeyChild, %{})
+      assert [child] = children
+      assert child.name == "Kid"
+      assert child.parent_code == parent.code
     end
   end
 end


### PR DESCRIPTION
## Bug

Nested association create (#137) never actually linked children to parents. Two compounding bugs:

1. `child_fk/3` returned `child_assoc.related_key` — for a child `belongs_to`, that's the **parent's PK field** (e.g. `:id`), not the child's FK. `build_child` then did `Map.put(child, :id, record.id)`, clobbering the child's own PK with the parent's id and never setting the FK.
2. Even with the right FK field, the value was put on the struct — but `changeset_for` casts from `attrs`, so the struct value was dropped on cast. Children were inserted with a nil FK.

Tests missed it because they only asserted on the parent, never on the child's FK.

## Fix

- `child_fk/3` now returns `{owner_key, related_key}` = `{child FK field, parent referenced PK field}`.
- New `link_child/3` injects the parent's PK value into the child's **cast attrs** before the changeset is built, so it survives casting.
- Dropped the `record.id` hardcode — `Map.get(record, pk)` handles custom/composite PK parents without `KeyError`.

## Verification

- Tests now assert children/profiles actually carry the correct FK (`child.parent_id == parent.id`, `child.parent_code == parent.code`).
- New test: nested create with a custom (binary_id, non-`:id`) parent PK.
- 830 tests pass, 1 skipped (pre-existing), 0 Dialyzer errors, credo + format clean.