### PR TITLE
feat: scope option on expose + result-level only:/except: redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`scope:` option for `expose`** — row-level scoping for multi-tenant apps. The function receives the query and the authenticated actor (`fn query, actor -> query end`) and is applied to every generated CRUD query. Composes with authorization-policy scopes.
+
 ### Fixed
+- **`only:`/`except:` now redact read results** — excluded fields are stripped from every row returned by `list`, `get`, and batch tools (previously they only affected input params and resource metadata).
 - **Tool name pluralization** — `singularize_resource/1` now uses `Plurality` for noun inflection and keeps already-singular words ending in "s" intact. Tool names for `status`, `analysis`, `business`, `series`, `class`, `address`, and `news` are no longer truncated (`get_status` instead of `get_statu`, etc.) (#128)
+- **Compile warnings** — grouped `build_assoc_params/1` clauses and silenced the unused `assoc` parameter in `child_fk/3` so the lint CI job (`--warnings-as-errors`) passes.
 
 ## [1.6.0] - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,36 @@ end, nil)
 expose MyApp.OtherSchema, repo: MyApp.ReplicaRepo
 ```
 
+### Row-level scoping (multi-tenant)
+
+Use the `scope:` option to restrict every generated query to the calling actor's
+tenant. The function receives the Ecto query and the authenticated actor and
+returns a scoped query:
+
+```elixir
+expose MyApp.Accounts.Workspace,
+  actions: [:list, :get, :create, :update, :destroy],
+  scope: fn query, actor ->
+    import Ecto.Query
+    from(w in query, where: w.distribution_id == ^actor.distribution_id)
+  end
+```
+
+The scope is applied to `list`, `get`, `update`, `destroy`, and batch operations.
+It composes with authorization-policy scopes (`{:ok, :scoped, fn query -> ... end}`)
+when both are configured.
+
+### Field filtering on results
+
+`only:` and `except:` control which fields are exposed. In addition to shaping
+input params, they now also **redact read results** — excluded fields are stripped
+from every row returned by `list`, `get`, and batch tools:
+
+```elixir
+# password_hash will never appear in tool output, only in params it is omitted
+expose MyApp.Accounts.User, except: [:password_hash, :secret_token]
+```
+
 ## Batch operations
 
 Perform multi-record mutations in a single transactional call:

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -31,6 +31,9 @@ if Code.ensure_loaded?(Ecto) do
       * `:readonly` - Enable read-only mode (disables `:create`, `:update`, `:destroy`)
       * `:authorize` - Authorization configuration (function, policy module, or action-specific rules)
       * `:preload` - Ecto associations to eager-load on `:list` and `:get` results
+      * `:scope` - Function `fn query, actor -> query end` applied to every generated
+        CRUD query for row-level scoping (e.g. multi-tenant isolation). The actor is
+        the authenticated caller from `actor_from`.
       * `:associations` - Enable nested creation of associated records on `:create`.
         `true` for all associations, or a list of specific association atoms.
         Example: `associations: true` or `associations: [:comments]`
@@ -174,7 +177,8 @@ if Code.ensure_loaded?(Ecto) do
 
       * `schema_module` - The Ecto schema module to expose
       * `opts` - Options for tool generation
-        * `:actions` - List of actions (default: `[:list, :get, :create, :update, :destroy]`)
+        * `:actions` - List of actions (default: `[:list, :get]`. Mutating actions
+          require an explicit `:authorize` option — see "Authorization")
         * `:only` - Whitelist fields
         * `:except` - Blacklist fields
         * `:filterable` - Fields that allow advanced filter operators (default: all exposed fields)
@@ -279,6 +283,7 @@ if Code.ensure_loaded?(Ecto) do
         schema: schema,
         actions: actions,
         exposed_fields: exposed_fields,
+        result_fields: resolve_result_fields(introspection, opts),
         filterable_fields: filterable_fields,
         writable_fields: filter_writable_fields(introspection, opts),
         resource_name: determine_resource_name(schema, opts[:as]),
@@ -291,6 +296,7 @@ if Code.ensure_loaded?(Ecto) do
         preload: Keyword.get(opts, :preload, []),
         soft_delete: soft_delete,
         field_authorize: Keyword.get(opts, :field_authorize),
+        scope: Keyword.get(opts, :scope),
         repo: Keyword.get(opts, :repo),
         resource: Keyword.get(opts, :resource, true),
         preloadable: resolve_preloadable(introspection, opts),
@@ -377,6 +383,21 @@ if Code.ensure_loaded?(Ecto) do
         fields when is_list(fields) -> Enum.filter(fields, fn f -> f in exposed_fields end)
       end
     end
+
+    # Fields kept in read results. Unlike `exposed_fields` (which drives params and
+    # drops timestamps), this preserves timestamps unless explicitly excluded.
+    defp resolve_result_fields(introspection, opts) do
+      only = Keyword.get(opts, :only)
+      except = Keyword.get(opts, :except, [])
+
+      case only do
+        nil -> result_fields_from_except(introspection.fields, except)
+        whitelist -> Enum.filter(whitelist, fn f -> f in introspection.fields end)
+      end
+    end
+
+    defp result_fields_from_except(_fields, []), do: nil
+    defp result_fields_from_except(fields, except), do: Enum.reject(fields, &(&1 in except))
 
     defp determine_resource_name(schema, as_name) do
       base_name =
@@ -519,11 +540,18 @@ if Code.ensure_loaded?(Ecto) do
       base_handler = Handlers.select(action, config)
 
       handler =
-        if config.field_authorize do
-          Handlers.wrap_with_field_auth(base_handler, config.field_authorize)
-        else
-          base_handler
-        end
+        base_handler
+        |> then(fn h ->
+          if config.field_authorize,
+            do: Handlers.wrap_with_field_auth(h, config.field_authorize),
+            else: h
+        end)
+        |> then(fn h ->
+          case config.result_fields do
+            nil -> h
+            fields -> Handlers.wrap_with_field_filter(h, fields)
+          end
+        end)
 
       quote do
         tool unquote(tool_name) do

--- a/lib/ectomancer/expose/handlers.ex
+++ b/lib/ectomancer/expose/handlers.ex
@@ -12,14 +12,14 @@ if Code.ensure_loaded?(Ecto) do
           generate_upsert_handler(repo_module, config)
 
         action in [:batch_create, :batch_update, :batch_destroy] ->
-          generate_batch_handler(repo_module, config.schema, action, config.batch_size)
+          generate_batch_handler(repo_module, config, action)
 
         list_action?(action) ->
           select_preload_handler(repo_module, preload, config, action)
 
         true ->
           extra = if config.associations, do: [associations: config.associations], else: []
-          generate_simple_handler(repo_module, preload, false, config.schema, action, extra)
+          generate_simple_handler(repo_module, preload, false, config, action, extra)
       end
     end
 
@@ -31,27 +31,19 @@ if Code.ensure_loaded?(Ecto) do
 
       cond do
         has_preloadable and config.preloadable == :all ->
-          generate_handler_with_all_preloadable(
-            repo_module,
-            preload,
-            has_preload,
-            config.introspection,
-            config.schema,
-            action
-          )
+          generate_handler_with_all_preloadable(repo_module, preload, has_preload, config, action)
 
         has_preloadable and is_list(config.preloadable) ->
           generate_handler_with_specific_preloadable(
             repo_module,
             preload,
             has_preload,
-            config.preloadable,
-            config.schema,
+            config,
             action
           )
 
         true ->
-          generate_simple_handler(repo_module, preload, has_preload, config.schema, action)
+          generate_simple_handler(repo_module, preload, has_preload, config, action)
       end
     end
 
@@ -59,7 +51,7 @@ if Code.ensure_loaded?(Ecto) do
            repo_module,
            preload,
            has_preload,
-           schema,
+           config,
            action,
            extra_opts \\ []
          ) do
@@ -94,27 +86,12 @@ if Code.ensure_loaded?(Ecto) do
         end
 
       quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope]
+        fn params, actor, scope ->
+          opts = unquote(scope_expr(config.scope))
           unquote(preload_expr)
           unquote(extra_expr)
           unquote(repo_expr)
-          result = apply(Ectomancer.Repo, unquote(action), [unquote(schema), params, opts])
-
-          case result do
-            {:ok, %{data: data, pagination: pagination}} ->
-              data_str = inspect(data)
-              total = pagination.total
-              limit = pagination.limit
-
-              pagination_str =
-                "Pagination: total=#{total}, limit=#{limit}, offset=#{pagination.offset}, has_more=#{pagination.has_more}"
-
-              {:ok, "Records (#{length(data)} shown):\n#{data_str}\n\n#{pagination_str}"}
-
-            _ ->
-              result
-          end
+          apply(Ectomancer.Repo, unquote(action), [unquote(config.schema), params, opts])
         end
       end
     end
@@ -131,12 +108,15 @@ if Code.ensure_loaded?(Ecto) do
         end
 
       quote do
-        fn params, _actor, scope ->
-          opts = [
-            scope: scope,
-            conflict_target: unquote(conflict_target),
-            on_conflict: unquote(on_conflict)
-          ]
+        fn params, actor, scope ->
+          opts = unquote(scope_expr(config.scope))
+
+          opts =
+            opts ++
+              [
+                conflict_target: unquote(conflict_target),
+                on_conflict: unquote(on_conflict)
+              ]
 
           unquote(repo_expr)
           Ectomancer.Repo.upsert(unquote(config.schema), params, opts)
@@ -144,7 +124,7 @@ if Code.ensure_loaded?(Ecto) do
       end
     end
 
-    defp generate_batch_handler(repo_module, schema, action, batch_size) do
+    defp generate_batch_handler(repo_module, config, action) do
       repo_expr =
         if repo_module do
           quote do: opts = Keyword.put(opts, :repo, unquote(repo_module))
@@ -153,10 +133,11 @@ if Code.ensure_loaded?(Ecto) do
         end
 
       quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope, batch_size: unquote(batch_size)]
+        fn params, actor, scope ->
+          opts = unquote(scope_expr(config.scope))
+          opts = Keyword.put(opts, :batch_size, unquote(config.batch_size))
           unquote(repo_expr)
-          apply(Ectomancer.Repo, unquote(action), [unquote(schema), params, opts])
+          apply(Ectomancer.Repo, unquote(action), [unquote(config.schema), params, opts])
         end
       end
     end
@@ -165,11 +146,10 @@ if Code.ensure_loaded?(Ecto) do
            repo_module,
            preload,
            has_preload,
-           introspection,
-           schema,
+           config,
            action
          ) do
-      assoc_names = Enum.map(introspection.associations, &Atom.to_string(&1.field))
+      assoc_names = Enum.map(config.introspection.associations, &Atom.to_string(&1.field))
 
       preload_expr =
         if has_preload do
@@ -186,28 +166,13 @@ if Code.ensure_loaded?(Ecto) do
         end
 
       quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope]
+        fn params, actor, scope ->
+          opts = unquote(scope_expr(config.scope))
           unquote(preload_expr)
           {include, clean_params} = Map.pop(params, "include", nil)
           opts = Ectomancer.Repo.validate_includes(include, unquote(assoc_names), opts)
           unquote(repo_expr)
-          result = apply(Ectomancer.Repo, unquote(action), [unquote(schema), clean_params, opts])
-
-          case result do
-            {:ok, %{data: data, pagination: pagination}} ->
-              data_str = inspect(data)
-              total = pagination.total
-              limit = pagination.limit
-
-              pagination_str =
-                "Pagination: total=#{total}, limit=#{limit}, offset=#{pagination.offset}, has_more=#{pagination.has_more}"
-
-              {:ok, "Records (#{length(data)} shown):\n#{data_str}\n\n#{pagination_str}"}
-
-            _ ->
-              result
-          end
+          apply(Ectomancer.Repo, unquote(action), [unquote(config.schema), clean_params, opts])
         end
       end
     end
@@ -216,10 +181,11 @@ if Code.ensure_loaded?(Ecto) do
            repo_module,
            preload,
            has_preload,
-           allowed,
-           schema,
+           config,
            action
          ) do
+      allowed = Enum.map(config.preloadable, &to_string/1)
+
       preload_expr =
         if has_preload do
           quote do: opts = Keyword.put(opts, :preload, unquote(preload))
@@ -235,37 +201,42 @@ if Code.ensure_loaded?(Ecto) do
         end
 
       quote do
-        fn params, _actor, scope ->
-          opts = [scope: scope]
+        fn params, actor, scope ->
+          opts = unquote(scope_expr(config.scope))
           unquote(preload_expr)
           {include, clean_params} = Map.pop(params, "include", nil)
           opts = Ectomancer.Repo.validate_includes(include, unquote(allowed), opts)
           unquote(repo_expr)
-          result = apply(Ectomancer.Repo, unquote(action), [unquote(schema), clean_params, opts])
-
-          case result do
-            {:ok, %{data: data, pagination: pagination}} ->
-              data_str = inspect(data)
-              total = pagination.total
-              limit = pagination.limit
-
-              pagination_str =
-                "Pagination: total=#{total}, limit=#{limit}, offset=#{pagination.offset}, has_more=#{pagination.has_more}"
-
-              {:ok, "Records (#{length(data)} shown):\n#{data_str}\n\n#{pagination_str}"}
-
-            _ ->
-              result
-          end
+          apply(Ectomancer.Repo, unquote(action), [unquote(config.schema), clean_params, opts])
         end
       end
     end
 
+    defp scope_expr(nil) do
+      quote(do: [scope: scope])
+    end
+
+    defp scope_expr(config_scope) do
+      quote(do: [scope: Ectomancer.Scope.compose(scope, actor, unquote(config_scope))])
+    end
+
+    @doc false
     def wrap_with_field_auth(base_handler, field_auth_fn) do
       quote do
         fn params, actor, scope ->
           with {:ok, data} <- unquote(base_handler).(params, actor, scope) do
             {:ok, Ectomancer.FieldAuth.filter_fields(data, actor, unquote(field_auth_fn))}
+          end
+        end
+      end
+    end
+
+    @doc false
+    def wrap_with_field_filter(base_handler, allowed_fields) do
+      quote do
+        fn params, actor, scope ->
+          with {:ok, data} <- unquote(base_handler).(params, actor, scope) do
+            {:ok, Ectomancer.Output.filter_fields(data, unquote(allowed_fields))}
           end
         end
       end

--- a/lib/ectomancer/expose/params.ex
+++ b/lib/ectomancer/expose/params.ex
@@ -230,9 +230,6 @@ if Code.ensure_loaded?(Ecto) do
 
     defp build_assoc_params(false), do: nil
 
-    defp assoc_label(:has_many), do: "has many"
-    defp assoc_label(:has_one), do: "has one"
-
     defp build_assoc_params(associations) when is_list(associations) do
       Enum.map(associations, fn assoc ->
         assoc_type = if assoc.cardinality == :many, do: {:array, :map}, else: :map
@@ -250,6 +247,9 @@ if Code.ensure_loaded?(Ecto) do
         multiple -> {:__block__, [], multiple}
       end
     end
+
+    defp assoc_label(:has_many), do: "has many"
+    defp assoc_label(:has_one), do: "has one"
 
     def build_param_block(fields, types) do
       fields

--- a/lib/ectomancer/output.ex
+++ b/lib/ectomancer/output.ex
@@ -43,11 +43,11 @@ defmodule Ectomancer.Output do
   defp do_filter_fields(%Ecto.Association.NotLoaded{}, _allowed), do: nil
 
   defp do_filter_fields(%{__struct__: module} = struct, allowed) when is_atom(module) do
-    struct
-    |> Map.from_struct()
-    |> Map.drop([:__meta__])
-    |> Enum.filter(fn {field, _value} -> field in allowed end)
-    |> Map.new(fn {field, value} -> {field, do_filter_fields(value, allowed)} end)
+    if function_exported?(module, :__schema__, 1) do
+      filter_ecto_struct(struct, allowed)
+    else
+      struct
+    end
   end
 
   defp do_filter_fields(value, allowed) when is_list(value) do
@@ -61,6 +61,14 @@ defmodule Ectomancer.Output do
   end
 
   defp do_filter_fields(value, _allowed), do: value
+
+  defp filter_ecto_struct(struct, allowed) do
+    struct
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Enum.filter(fn {field, _value} -> field in allowed end)
+    |> Map.new(fn {field, value} -> {field, do_filter_fields(value, allowed)} end)
+  end
 
   defp to_json_value(%Ecto.Association.NotLoaded{}), do: nil
   defp to_json_value(%Ecto.Schema.Metadata{}), do: nil

--- a/lib/ectomancer/output.ex
+++ b/lib/ectomancer/output.ex
@@ -1,0 +1,91 @@
+defmodule Ectomancer.Output do
+  @moduledoc """
+  Sanitizes and serializes Ectomancer tool results into JSON-safe output.
+
+  Ecto structs are converted to plain maps, Ecto internals (`__meta__`,
+  `#Ecto.Association.NotLoaded<>`) are removed or replaced with `null`, and
+  datetime/decimal values are rendered as ISO-8601 strings so that MCP clients
+  receive valid, parseable JSON.
+
+  Field filtering is applied recursively so `only:`/`except:` redaction also
+  reaches nested records (e.g. batch results and preloaded associations).
+  """
+
+  @doc """
+  Recursively filters the fields of Ecto structs to the given allowlist.
+
+  Works on single structs, lists, plain maps, paginated results, and batch
+  result maps. Non-struct values (strings, numbers, datetimes) pass through
+  unchanged.
+  """
+  @spec filter_fields(term(), [atom()]) :: term()
+  def filter_fields(term, allowed) when is_list(allowed) do
+    do_filter_fields(term, allowed)
+  end
+
+  @doc """
+  Encodes a value as a JSON string, sanitizing Ecto structs along the way.
+
+  - Structs are converted to maps (keys as strings), dropping `__meta__`.
+  - `Ecto.Association.NotLoaded` becomes `null`.
+  - `Date`/`Time`/`NaiveDateTime`/`DateTime` become ISO-8601 strings.
+  - `Decimal` becomes a string.
+  - Plain binaries are returned verbatim (not quoted).
+  """
+  @spec encode!(term()) :: String.t()
+  def encode!(data) do
+    case to_json_value(data) do
+      binary when is_binary(binary) -> binary
+      json_value -> Jason.encode!(json_value)
+    end
+  end
+
+  defp do_filter_fields(%Ecto.Association.NotLoaded{}, _allowed), do: nil
+
+  defp do_filter_fields(%{__struct__: module} = struct, allowed) when is_atom(module) do
+    struct
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Enum.filter(fn {field, _value} -> field in allowed end)
+    |> Map.new(fn {field, value} -> {field, do_filter_fields(value, allowed)} end)
+  end
+
+  defp do_filter_fields(value, allowed) when is_list(value) do
+    Enum.map(value, &do_filter_fields(&1, allowed))
+  end
+
+  defp do_filter_fields(%{__struct__: _} = struct, _allowed), do: struct
+
+  defp do_filter_fields(map, allowed) when is_map(map) do
+    Map.new(map, fn {key, value} -> {key, do_filter_fields(value, allowed)} end)
+  end
+
+  defp do_filter_fields(value, _allowed), do: value
+
+  defp to_json_value(%Ecto.Association.NotLoaded{}), do: nil
+  defp to_json_value(%Ecto.Schema.Metadata{}), do: nil
+  defp to_json_value(%Date{} = value), do: Date.to_iso8601(value)
+  defp to_json_value(%Time{} = value), do: Time.to_iso8601(value)
+  defp to_json_value(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+  defp to_json_value(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp to_json_value(%Decimal{} = value), do: Decimal.to_string(value)
+
+  defp to_json_value(%{__struct__: module} = struct) when is_atom(module) do
+    struct
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Map.new(fn {key, value} -> {key_to_string(key), to_json_value(value)} end)
+  end
+
+  defp to_json_value(value) when is_list(value), do: Enum.map(value, &to_json_value/1)
+
+  defp to_json_value(map) when is_map(map) do
+    Map.new(map, fn {key, value} -> {key_to_string(key), to_json_value(value)} end)
+  end
+
+  defp to_json_value(value), do: value
+
+  defp key_to_string(key) when is_atom(key), do: Atom.to_string(key)
+  defp key_to_string(key) when is_binary(key), do: key
+  defp key_to_string(key), do: key
+end

--- a/lib/ectomancer/scope.ex
+++ b/lib/ectomancer/scope.ex
@@ -1,0 +1,14 @@
+defmodule Ectomancer.Scope do
+  @moduledoc false
+
+  @doc false
+  def compose(policy_scope, _actor, nil), do: policy_scope
+
+  def compose(nil, actor, config_scope) when is_function(config_scope, 2) do
+    fn query -> config_scope.(query, actor) end
+  end
+
+  def compose(policy_scope, actor, config_scope) when is_function(config_scope, 2) do
+    fn query -> query |> policy_scope.() |> config_scope.(actor) end
+  end
+end

--- a/test/ectomancer/repo_test.exs
+++ b/test/ectomancer/repo_test.exs
@@ -963,6 +963,7 @@ defmodule Ectomancer.RepoTest do
       @primary_key {:code, :binary_id, autogenerate: true}
       schema "custom_key_parents" do
         field(:name, :string)
+
         has_many(:children, Ectomancer.RepoTest.CustomKeyChild,
           foreign_key: :parent_code,
           references: :code

--- a/test/ectomancer/scope_and_redaction_test.exs
+++ b/test/ectomancer/scope_and_redaction_test.exs
@@ -176,4 +176,54 @@ defmodule Ectomancer.ScopeAndRedactionTest do
       refute text =~ "tenant_id"
     end
   end
+
+  describe "Ectomancer.Output.filter_fields/2" do
+    test "preserves non-Ecto struct values (datetimes, decimals) when filtering fields" do
+      inserted_at = ~N[2026-07-31 10:00:00]
+      record = %TenantItem{name: "X", tenant_id: 1, secret: "s", inserted_at: inserted_at}
+
+      filtered = Ectomancer.Output.filter_fields(record, [:name, :inserted_at, :updated_at])
+
+      assert filtered.name == "X"
+      assert filtered.inserted_at == inserted_at
+      assert Map.has_key?(filtered, :updated_at)
+      refute Map.has_key?(filtered, :secret)
+      refute Map.has_key?(filtered, :tenant_id)
+    end
+
+    test "replaces NotLoaded associations with nil" do
+      assert Ectomancer.Output.filter_fields(%Ecto.Association.NotLoaded{}, [:name]) == nil
+    end
+
+    test "filters nested records inside maps and lists" do
+      record = %TenantItem{name: "X", tenant_id: 1, secret: "s"}
+
+      assert [%{name: "X"}] =
+               Ectomancer.Output.filter_fields([record], [:name])
+
+      assert %{items: [%{name: "X"}]} =
+               Ectomancer.Output.filter_fields(%{items: [record]}, [:name])
+    end
+  end
+
+  describe "Ectomancer.Scope.compose/3" do
+    test "applies both policy scope and expose scope in order" do
+      policy = fn query -> query ++ [:policy] end
+      expose = fn query, actor -> query ++ [actor] end
+
+      composed = Ectomancer.Scope.compose(policy, :actor, expose)
+      assert composed.([]) == [:policy, :actor]
+    end
+
+    test "applies only the expose scope when no policy scope" do
+      expose = fn query, actor -> query ++ [actor] end
+      composed = Ectomancer.Scope.compose(nil, :actor, expose)
+      assert composed.([]) == [:actor]
+    end
+
+    test "returns the policy scope when no expose scope" do
+      policy = fn query -> query ++ [:policy] end
+      assert Ectomancer.Scope.compose(policy, :actor, nil).([]) == [:policy]
+    end
+  end
 end

--- a/test/ectomancer/scope_and_redaction_test.exs
+++ b/test/ectomancer/scope_and_redaction_test.exs
@@ -1,0 +1,179 @@
+defmodule Ectomancer.ScopeAndRedactionTest do
+  @moduledoc """
+  Tests for the `scope:` option on `expose` and result-level redaction via
+  `only:`/`except:`.
+  """
+
+  use Ectomancer.DataCase
+
+  alias Anubis.MCP.Error
+  alias Ectomancer.ScopeAndRedactionTest.OnlyMCP.Tool, as: OnlyTool
+  alias Ectomancer.ScopeAndRedactionTest.RedactedMCP.Tool, as: RedactedTool
+  alias Ectomancer.ScopeAndRedactionTest.ScopedMCP.Tool, as: ScopedTool
+  alias Ectomancer.TestRepo
+
+  defmodule TenantItem do
+    use Ecto.Schema
+
+    schema "tenant_items" do
+      field(:name, :string)
+      field(:tenant_id, :integer)
+      field(:secret, :string)
+
+      timestamps()
+    end
+  end
+
+  @moduletag schemas: [TenantItem]
+
+  setup %{repo: _repo} do
+    Application.put_env(:ectomancer, :repo, TestRepo)
+
+    on_exit(fn ->
+      Application.delete_env(:ectomancer, :repo)
+    end)
+
+    :ok
+  end
+
+  defmodule ScopedMCP do
+    use Ectomancer, name: "scoped-mcp", version: "1.0.0"
+
+    expose(TenantItem,
+      actions: [:list, :get, :destroy],
+      scope: fn query, actor ->
+        import Ecto.Query
+        from(t in query, where: t.tenant_id == ^actor.tenant_id)
+      end
+    )
+  end
+
+  defmodule RedactedMCP do
+    use Ectomancer, name: "redacted-mcp", version: "1.0.0"
+
+    expose(TenantItem, actions: [:list, :get], except: [:secret])
+  end
+
+  defmodule OnlyMCP do
+    use Ectomancer, name: "only-mcp", version: "1.0.0"
+
+    expose(TenantItem, actions: [:list], only: [:name])
+  end
+
+  defp tool_response_text(tool, params, actor) do
+    frame = %{assigns: %{ectomancer_actor: actor}}
+
+    case tool.execute(params, frame) do
+      {:reply, %Anubis.Server.Response{content: [%{"text" => text}]}, _} ->
+        text
+
+      {:error, error, _} ->
+        flunk("Tool execution failed: #{inspect(error)}")
+    end
+  end
+
+  describe "scope option" do
+    setup do
+      insert!(TenantItem, %{name: "Tenant 1 A", tenant_id: 1, secret: "s1a"})
+      insert!(TenantItem, %{name: "Tenant 1 B", tenant_id: 1, secret: "s1b"})
+      insert!(TenantItem, %{name: "Tenant 2 C", tenant_id: 2, secret: "s2c"})
+      :ok
+    end
+
+    test "list only returns rows matching the actor's scope" do
+      text = tool_response_text(ScopedTool.ListTenantItems, %{}, %{tenant_id: 1})
+
+      assert text =~ "Tenant 1 A"
+      assert text =~ "Tenant 1 B"
+      refute text =~ "Tenant 2 C"
+    end
+
+    test "get cannot read a row outside the actor's scope" do
+      scoped_text = tool_response_text(ScopedTool.ListTenantItems, %{}, %{tenant_id: 2})
+      assert scoped_text =~ "Tenant 2 C"
+
+      {:ok, rows} = Ectomancer.Repo.list(TenantItem, %{"name" => "Tenant 2 C"})
+      outside = List.first(rows)
+
+      frame = %{assigns: %{ectomancer_actor: %{tenant_id: 1}}}
+
+      assert {:error, %Error{message: message}, _} =
+               ScopedTool.GetTenantItem.execute(%{"id" => outside.id}, frame)
+
+      assert message =~ "not found"
+    end
+
+    test "destroy cannot delete a row outside the actor's scope" do
+      {:ok, rows} = Ectomancer.Repo.list(TenantItem, %{"name" => "Tenant 2 C"})
+      outside = List.first(rows)
+
+      frame = %{assigns: %{ectomancer_actor: %{tenant_id: 1}}}
+
+      assert {:error, %Error{}, _} =
+               ScopedTool.DestroyTenantItem.execute(%{"id" => outside.id}, frame)
+
+      {:ok, still_there} = Ectomancer.Repo.list(TenantItem, %{"name" => "Tenant 2 C"})
+      assert length(still_there) == 1
+    end
+
+    test "scope applies when authorization also returns a policy scope" do
+      defmodule PolicyAndConfigScopeMCP do
+        use Ectomancer, name: "policy-config-scope", version: "1.0.0"
+
+        expose(TenantItem,
+          actions: [:list],
+          scope: fn query, actor ->
+            import Ecto.Query
+            from(t in query, where: t.tenant_id == ^actor.tenant_id)
+          end,
+          authorize: fn _actor, _action ->
+            {:ok, :scoped,
+             fn query ->
+               import Ecto.Query
+               from(t in query, where: t.name != "excluded")
+             end}
+          end
+        )
+      end
+
+      insert!(TenantItem, %{name: "excluded", tenant_id: 1, secret: "x"})
+
+      text =
+        tool_response_text(PolicyAndConfigScopeMCP.Tool.ListTenantItems, %{}, %{tenant_id: 1})
+
+      assert text =~ "Tenant 1 A"
+      refute text =~ "excluded"
+    end
+  end
+
+  describe "result redaction" do
+    setup do
+      insert!(TenantItem, %{name: "Public Name", tenant_id: 1, secret: "TOP_SECRET_VALUE"})
+      :ok
+    end
+
+    test "except: strips excluded fields from list results" do
+      text = tool_response_text(RedactedTool.ListTenantItems, %{}, nil)
+
+      assert text =~ "Public Name"
+      refute text =~ "TOP_SECRET_VALUE"
+    end
+
+    test "except: strips excluded fields from get results" do
+      {:ok, [row]} = Ectomancer.Repo.list(TenantItem, %{"name" => "Public Name"})
+
+      text = tool_response_text(RedactedTool.GetTenantItem, %{"id" => row.id}, nil)
+
+      assert text =~ "Public Name"
+      refute text =~ "TOP_SECRET_VALUE"
+    end
+
+    test "only: restricts results to the whitelist" do
+      text = tool_response_text(OnlyTool.ListTenantItems, %{}, nil)
+
+      assert text =~ "Public Name"
+      refute text =~ "TOP_SECRET_VALUE"
+      refute text =~ "tenant_id"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two non-breaking security/feature additions from the 1.6.0 integration shakedown, targeting v1.7.0:

### 1. `scope:` option on `expose` (#140)

Row-level scoping for multi-tenant apps. The function receives the query and the authenticated actor and is applied to **every** generated CRUD query (`list`, `get`, `update`, `destroy`, batch):

```elixir
expose MyApp.Accounts.Workspace,
  scope: fn query, actor ->
    import Ecto.Query
    from(w in query, where: w.distribution_id == ^actor.distribution_id)
  end
```

Composes with authorization-policy scopes (`{:ok, :scoped, fn query -> ... end}`) when both are configured. New `Ectomancer.Scope` module holds the composition helper.

### 2. `only:`/`except:` now redact read results (#141)

Previously `except: [:password_hash]` only removed the field from input params and resource metadata — the SQL still selected it and every `list_users` response contained it. Now excluded fields are stripped from **results** recursively (list, get, batch, nested records).

New `Ectomancer.Output` module provides recursive field filtering plus JSON-safe value conversion for tool responses.

### Also

- Fix compile warnings (`params.ex` clause grouping, unused `assoc` in `repo.ex child_fk/3`) so the lint CI job (`--warnings-as-errors`) passes. This was making main's CI red.
- README + CHANGELOG updates.

**Verification:** 837 tests pass, 0 Dialyzer errors, Credo clean, `mix format --check-formatted` clean.