### PR TITLE
docs: fix authorize keyword syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ defmodule MyApp.MCP do
   use Ectomancer,
     name: "myapp-mcp",
     version: "0.1.0",
-    authorize: with: MyApp.Policies.GlobalPolicy
+    authorize: [with: MyApp.Policies.GlobalPolicy]
 
   expose MyApp.Accounts.User,
     actions: [:list, :get, :create, :update]
@@ -294,7 +294,7 @@ You can also use a policy module:
 ```elixir
 use Ectomancer,
   name: "myapp-mcp",
-  authorize: with: MyApp.Policies.GlobalPolicy
+  authorize: [with: MyApp.Policies.GlobalPolicy]
 ```
 
 Per-schema `authorize` overrides the global policy for that schema. Action-specific rules override further. Both must pass when both are set (cascading).

--- a/lib/ectomancer/expose.ex
+++ b/lib/ectomancer/expose.ex
@@ -106,7 +106,7 @@ if Code.ensure_loaded?(Ecto) do
 
         # Policy module
         expose MyApp.Accounts.User,
-          authorize: with: MyApp.Policies.UserPolicy
+          authorize: [with: MyApp.Policies.UserPolicy]
 
         # Action-specific authorization
         expose MyApp.Accounts.User,


### PR DESCRIPTION
## Description

Corrects the global and per-schema authorization examples to use valid nested keyword-list syntax.

Fixes #151

## Type of change

- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

## Testing

Searched the README and module documentation for the invalid `authorize: with:` form; no occurrences remain. The Elixir toolchain is unavailable in this environment, so Mix checks were not run.
