### PR TITLE
fix: batch/include param keys, JSON tool output, batch savepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README + `Ectomancer.Plug` docs updated to the working supervision form.
 
 ### Fixed
+- **Tool results are now JSON, not `inspect/1` output** (#147). Responses are serialized through a sanitizer that converts Ecto structs to plain maps, drops `__meta__`, replaces `NotLoaded` with `null`, and renders datetimes as ISO-8601. `inspect/1`'s silent 50-row truncation is gone, and error responses no longer echo full stacktraces.
+- **Batch operations no longer silently no-op** (#145). Anubis delivers params with atom keys; the batch handlers read string keys, so `batch_create` reported `total: 0`. Param keys are now normalized once at the tool-execution funnel, and `Repo.batch_*` read both key shapes.
+- **`include`/`preloadable` actually preloads** (#146). The `include` param is honored after the key-normalization fix, and `validate_includes/3` no longer crashes on string allowlists (removed the dead `:all` clause that also did unbounded `String.to_atom`).
+- **Batch operations isolate per-record failures** (#153). Each per-item write runs in a savepoint so a database-level constraint violation cannot poison the surrounding transaction; the documented partial-failure semantics are kept and the README no longer claims batches are atomic.
 - **`only:`/`except:` now redact read results** — excluded fields are stripped from every row returned by `list`, `get`, and batch tools (previously they only affected input params and resource metadata).
 - **Tool name pluralization** — `singularize_resource/1` now uses `Plurality` for noun inflection and keeps already-singular words ending in "s" intact. Tool names for `status`, `analysis`, `business`, `series`, `class`, `address`, and `news` are no longer truncated (`get_status` instead of `get_statu`, etc.) (#128)
 - **Compile warnings** — grouped `build_assoc_params/1` clauses and silenced the unused `assoc` parameter in `child_fk/3` so the lint CI job (`--warnings-as-errors`) passes.

--- a/README.md
+++ b/README.md
@@ -434,15 +434,21 @@ expose MyApp.Accounts.User,
 
 | Action | Tool Name | Input | Behavior |
 |--------|-----------|-------|----------|
-| `batch_create` | `batch_create_users` | `records: [%{...}]` | Validates all, inserts in transaction |
-| `batch_update` | `batch_update_users` | `records: [%{id, ...}]` | Fetches each, updates in transaction |
-| `batch_destroy` | `batch_destroy_users` | `ids: [...]` | Fetches each, soft/hard-deletes atomically |
+| `batch_create` | `batch_create_users` | `records: [%{...}]` | Validates and inserts each record in a single transaction |
+| `batch_update` | `batch_update_users` | `records: [%{id, ...}]` | Fetches and updates each record in a single transaction |
+| `batch_destroy` | `batch_destroy_users` | `ids: [...]` | Fetches and deletes each record in a single transaction |
 
-Partial failures are reported alongside successes — the AI assistant can retry or report the failed records:
+Each record is processed inside the shared transaction, and a database-level
+failure on one record is contained by a savepoint so it cannot abort the rest of
+the batch. **The batch is best-effort, not atomic** — records that succeed are
+committed even when others fail:
 
 ```elixir
 # Result shape: %{succeeded: [%{status: :ok, record: ...}], failed: [...], total: 3}
 ```
+
+Partial failures are reported alongside successes so the AI assistant can retry
+or report the failed records.
 
 Batch operations respect authorization, scope, soft-delete, and field auth just like single-record operations.
 

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -464,7 +464,7 @@ if Code.ensure_loaded?(Ecto) do
     def batch_create(schema_module, params, opts \\ []) do
       Ectomancer.Telemetry.repo_span(:batch_create, schema_module, fn ->
         try do
-          records = Map.get(params || %{}, "records", [])
+          records = batch_entries(params, :records)
           batch_size = Keyword.get(opts, :batch_size, 100)
 
           if length(records) > batch_size do
@@ -507,7 +507,7 @@ if Code.ensure_loaded?(Ecto) do
     def batch_update(schema_module, params, opts \\ []) do
       Ectomancer.Telemetry.repo_span(:batch_update, schema_module, fn ->
         try do
-          records = Map.get(params || %{}, "records", [])
+          records = batch_entries(params, :records)
           batch_size = Keyword.get(opts, :batch_size, 100)
 
           if length(records) > batch_size do
@@ -547,8 +547,8 @@ if Code.ensure_loaded?(Ecto) do
     def batch_destroy(schema_module, params, opts \\ []) do
       Ectomancer.Telemetry.repo_span(:batch_destroy, schema_module, fn ->
         try do
-          ids = Map.get(params || %{}, "ids", [])
-          records = Map.get(params || %{}, "records", [])
+          ids = batch_entries(params, :ids)
+          records = batch_entries(params, :records)
           items = if records != [], do: records, else: ids
           batch_size = Keyword.get(opts, :batch_size, 100)
 
@@ -568,12 +568,18 @@ if Code.ensure_loaded?(Ecto) do
       end)
     end
 
+    defp batch_entries(nil, _key), do: []
+
+    defp batch_entries(params, key) when is_map(params) do
+      Map.get(params, to_string(key), Map.get(params, key, []))
+    end
+
     defp perform_batch_create(repo, schema_module, attrs) do
       struct = struct(schema_module)
       attrs = normalize_params(attrs, schema_module)
       changeset = build_create_changeset(schema_module, struct, attrs)
 
-      case repo.insert(changeset) do
+      case repo.insert(changeset, mode: :savepoint) do
         {:ok, record} -> {:ok, record}
         {:error, changeset} -> {:error, attrs, changeset}
       end
@@ -616,9 +622,9 @@ if Code.ensure_loaded?(Ecto) do
             if sd_field do
               now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
               changeset = Ecto.Changeset.change(record, %{sd_field => now})
-              repo.update(changeset)
+              repo.update(changeset, mode: :savepoint)
             else
-              repo.delete(record)
+              repo.delete(record, mode: :savepoint)
             end
 
           case result do
@@ -662,7 +668,7 @@ if Code.ensure_loaded?(Ecto) do
 
           changeset = build_changeset(schema_module, record, update_attrs, pk_fields)
 
-          case repo.update(changeset) do
+          case repo.update(changeset, mode: :savepoint) do
             {:ok, record} -> {:ok, record}
             {:error, changeset} -> {:error, record_attrs, changeset}
           end
@@ -1045,27 +1051,20 @@ if Code.ensure_loaded?(Ecto) do
     @doc """
     Validates dynamic include requests against allowed preloadable associations.
 
-    Returns the opts keyword list with merged preloads.
+    Returns the opts keyword list with merged preloads. `allowed` may be a list
+    of association atoms or strings; `include` entries not in the allowlist are
+    dropped.
     """
-    @spec validate_includes(list() | nil, :all | list(atom()), keyword()) :: keyword()
+    @spec validate_includes(list() | nil, list(atom() | String.t()), keyword()) :: keyword()
     def validate_includes(nil, _allowed, opts), do: opts
     def validate_includes([], _allowed, opts), do: opts
 
-    def validate_includes(include, :all, opts) when is_list(include) do
-      validated =
-        include
-        |> Enum.map(&String.to_atom/1)
-        |> Enum.reject(&is_nil(&1))
-
-      existing = Keyword.get(opts, :preload, [])
-      Keyword.put(opts, :preload, existing ++ validated)
-    end
-
     def validate_includes(include, allowed, opts) when is_list(include) and is_list(allowed) do
-      allowed_strs = Enum.map(allowed, &Atom.to_string/1)
+      allowed_strs = Enum.map(allowed, &to_string/1)
 
       validated =
         include
+        |> Enum.map(&to_string/1)
         |> Enum.filter(&(&1 in allowed_strs))
         |> Enum.map(&String.to_atom/1)
 

--- a/lib/ectomancer/tool.ex
+++ b/lib/ectomancer/tool.ex
@@ -171,6 +171,8 @@ if Code.ensure_loaded?(Ecto) do
           # only return {:ok, _} - the compiler can't track types through this function
           @dialyzer {:nowarn_function, do_execute: 5}
           defp do_execute(handler, params, scope, actor, frame) do
+            params = Ectomancer.Tool.normalize_param_keys(params)
+
             Ectomancer.Telemetry.tool_span(@tool_name, fn ->
               result =
                 cond do
@@ -189,7 +191,7 @@ if Code.ensure_loaded?(Ecto) do
                 {:ok, data} ->
                   response = %Anubis.Server.Response{
                     type: :tool,
-                    content: [%{"type" => "text", "text" => inspect(data)}]
+                    content: [%{"type" => "text", "text" => Ectomancer.Output.encode!(data)}]
                   }
 
                   {:reply, response, frame}
@@ -205,10 +207,7 @@ if Code.ensure_loaded?(Ecto) do
               error = %Anubis.MCP.Error{
                 code: -32_603,
                 message: "Tool execution error: #{Exception.message(e)}",
-                data: %{
-                  error: inspect(e),
-                  stacktrace: Exception.format_stacktrace(__STACKTRACE__)
-                }
+                data: %{error: inspect(e)}
               }
 
               {:error, error, frame}
@@ -452,6 +451,24 @@ if Code.ensure_loaded?(Ecto) do
         true -> :execute
       end
     end
+
+    @doc """
+    Normalizes tool-call parameter keys to strings.
+
+    Anubis validates against its Peri schema and delivers params with atom keys,
+    but handlers (batch `records`/`ids`, dynamic `include`) read string keys.
+    Normalizing once at the execution funnel makes every generated tool behave
+    identically regardless of whether the client sent atom or string keys.
+    """
+    @spec normalize_param_keys(map() | nil) :: map()
+    def normalize_param_keys(params) when is_map(params) do
+      Map.new(params, fn
+        {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+        {key, value} -> {key, value}
+      end)
+    end
+
+    def normalize_param_keys(params), do: params
 
     @doc """
     Formats error reasons into proper MCP error format with descriptive messages.

--- a/test/ectomancer/batch_output_include_test.exs
+++ b/test/ectomancer/batch_output_include_test.exs
@@ -1,0 +1,198 @@
+defmodule Ectomancer.BatchOutputIncludeTest do
+  @moduledoc """
+  Tests for batch param-key normalization (#145), dynamic include preloading
+  (#146), JSON tool output (#147), and batch savepoint isolation (#153).
+  """
+
+  use Ectomancer.DataCase
+
+  alias Ectomancer.TestRepo
+
+  defmodule Item do
+    use Ecto.Schema
+
+    schema "out_items" do
+      field(:name, :string)
+      field(:code, :string)
+
+      timestamps()
+    end
+  end
+
+  defmodule Comment do
+    use Ecto.Schema
+
+    schema "out_comments" do
+      field(:body, :string)
+      belongs_to(:post, Post)
+      timestamps()
+    end
+  end
+
+  defmodule Post do
+    use Ecto.Schema
+
+    schema "out_posts" do
+      field(:title, :string)
+      has_many(:comments, Comment, foreign_key: :post_id)
+      timestamps()
+    end
+  end
+
+  defmodule ItemMCP do
+    use Ectomancer, name: "batch-output-mcp", version: "1.0.0"
+
+    expose(Item, actions: [:list, :get, :create, :batch_create])
+  end
+
+  defmodule IncludeMCP do
+    use Ectomancer, name: "include-output-mcp", version: "1.0.0"
+
+    expose(Post, as: :post, actions: [:list, :get], preloadable: true)
+  end
+
+  @moduletag schemas: [Item, Post, Comment]
+
+  setup %{repo: _repo} do
+    Application.put_env(:ectomancer, :repo, TestRepo)
+
+    on_exit(fn ->
+      Application.delete_env(:ectomancer, :repo)
+    end)
+
+    :ok
+  end
+
+  defp execute(tool, params \\ %{}, actor \\ nil) do
+    frame = %{assigns: %{ectomancer_actor: actor}}
+
+    case tool.execute(params, frame) do
+      {:reply, %Anubis.Server.Response{content: [%{"text" => text}]}, _} -> {:ok, text}
+      {:error, error, _} -> {:error, error}
+    end
+  end
+
+  describe "tool results are JSON" do
+    test "list returns valid JSON with no struct noise" do
+      insert!(Item, %{name: "Alpha", code: "A1"})
+      insert!(Item, %{name: "Beta", code: "B2"})
+
+      assert {:ok, text} = execute(ItemMCP.Tool.ListItems)
+      decoded = Jason.decode!(text)
+
+      refute text =~ "__struct__"
+      refute text =~ "__meta__"
+      refute text =~ "NotLoaded"
+
+      assert is_list(decoded)
+      assert Enum.map(decoded, & &1["name"]) |> Enum.sort() == ["Alpha", "Beta"]
+    end
+
+    test "list with limit returns paginated JSON" do
+      insert!(Item, %{name: "Alpha", code: "A1"})
+      insert!(Item, %{name: "Beta", code: "B2"})
+
+      assert {:ok, text} = execute(ItemMCP.Tool.ListItems, %{"limit" => 1})
+      decoded = Jason.decode!(text)
+
+      assert %{"data" => data, "pagination" => pagination} = decoded
+      assert length(data) == 1
+      assert pagination["total"] == 2
+      assert pagination["limit"] == 1
+    end
+
+    test "get returns a JSON object, not a struct" do
+      insert!(Item, %{name: "Alpha", code: "A1"})
+      {:ok, [row]} = Ectomancer.Repo.list(Item, %{"name" => "Alpha"})
+
+      assert {:ok, text} = execute(ItemMCP.Tool.GetItem, %{"id" => row.id})
+      decoded = Jason.decode!(text)
+
+      assert decoded["name"] == "Alpha"
+      assert decoded["code"] == "A1"
+    end
+
+    test "create returns a JSON object" do
+      assert {:ok, text} = execute(ItemMCP.Tool.CreateItem, %{"name" => "New", "code" => "N1"})
+      decoded = Jason.decode!(text)
+      assert decoded["name"] == "New"
+    end
+  end
+
+  describe "batch operations accept atom-keyed params" do
+    test "Repo.batch_create with atom records key" do
+      assert {:ok, result} =
+               Ectomancer.Repo.batch_create(Item, %{records: [%{name: "X", code: "C1"}]})
+
+      assert result.total == 1
+      assert length(result.succeeded) == 1
+    end
+
+    test "batch_create tool accepts atom-keyed params" do
+      assert {:ok, text} =
+               execute(ItemMCP.Tool.BatchCreateItems, %{records: [%{name: "Y", code: "C2"}]})
+
+      decoded = Jason.decode!(text)
+      assert decoded["total"] == 1
+      assert length(decoded["succeeded"]) == 1
+    end
+  end
+
+  describe "dynamic include preloading" do
+    setup do
+      insert!(Post, %{title: "Post 1"})
+      insert!(Comment, %{body: "Comment 1", post_id: 1})
+      insert!(Comment, %{body: "Comment 2", post_id: 1})
+      :ok
+    end
+
+    test "include: preloads associations in list output" do
+      assert {:ok, text} = execute(IncludeMCP.Tool.ListPosts, %{"include" => ["comments"]})
+      decoded = Jason.decode!(text)
+
+      assert is_list(decoded)
+      assert hd(decoded)["comments"] != nil
+
+      assert Enum.map(hd(decoded)["comments"], & &1["body"]) |> Enum.sort() ==
+               ["Comment 1", "Comment 2"]
+    end
+
+    test "without include, associations are not leaked" do
+      assert {:ok, text} = execute(IncludeMCP.Tool.ListPosts)
+      refute text =~ "Comment 1"
+    end
+
+    test "disallowed include values are ignored" do
+      assert {:ok, text} = execute(IncludeMCP.Tool.ListPosts, %{"include" => ["hack"]})
+      decoded = Jason.decode!(text)
+      assert is_list(decoded)
+    end
+  end
+
+  describe "batch savepoints isolate database-level failures" do
+    test "a unique violation on one record does not abort the batch" do
+      Ectomancer.DataCase.create_unique_index!(Item, :code)
+      insert!(Item, %{name: "Existing", code: "DUP"})
+
+      assert {:ok, result} =
+               Ectomancer.Repo.batch_create(Item, %{
+                 "records" => [
+                   %{"name" => "New", "code" => "NEW1"},
+                   %{"name" => "Dup", "code" => "DUP"}
+                 ]
+               })
+
+      assert result.total == 2
+      assert length(result.succeeded) == 1
+      assert length(result.failed) == 1
+
+      # the surrounding transaction was not poisoned — a follow-up batch works
+      assert {:ok, second} =
+               Ectomancer.Repo.batch_create(Item, %{
+                 "records" => [%{"name" => "Zed", "code" => "Z9"}]
+               })
+
+      assert length(second.succeeded) == 1
+    end
+  end
+end

--- a/test/ectomancer/repo_test.exs
+++ b/test/ectomancer/repo_test.exs
@@ -60,26 +60,26 @@ defmodule Ectomancer.RepoTest do
   describe "validate_includes/3" do
     test "passes through nil include" do
       opts = [scope: nil]
-      assert Ectomancer.Repo.validate_includes(nil, :all, opts) == opts
+      assert Ectomancer.Repo.validate_includes(nil, [:posts], opts) == opts
     end
 
     test "passes through empty include" do
       opts = [scope: nil]
-      assert Ectomancer.Repo.validate_includes([], :all, opts) == opts
+      assert Ectomancer.Repo.validate_includes([], [:posts], opts) == opts
     end
 
-    test "allows all includes when allowed is :all" do
-      result = Ectomancer.Repo.validate_includes(["posts", "comments"], :all, [])
+    test "allows includes present in the allowed list" do
+      result = Ectomancer.Repo.validate_includes(["posts", "comments"], ["posts", "comments"], [])
       assert result[:preload] == [:posts, :comments]
     end
 
     test "filters includes by allowed list" do
-      result = Ectomancer.Repo.validate_includes(["secret", "public"], [:public], [])
+      result = Ectomancer.Repo.validate_includes(["secret", "public"], ["public"], [])
       assert result[:preload] == [:public]
     end
 
     test "merges with existing preloads" do
-      result = Ectomancer.Repo.validate_includes(["posts"], :all, preload: [:comments])
+      result = Ectomancer.Repo.validate_includes(["posts"], ["posts"], preload: [:comments])
       assert result[:preload] == [:comments, :posts]
     end
   end

--- a/test/ectomancer/tool_authorization_test.exs
+++ b/test/ectomancer/tool_authorization_test.exs
@@ -56,7 +56,7 @@ defmodule Ectomancer.ToolAuthorizationTest do
       frame = %{assigns: %{ectomancer_actor: %{role: :admin}}}
 
       assert {:reply, response, _} = AdminOnly.execute(%{}, frame)
-      assert response.content == [%{"type" => "text", "text" => ~s("Secret data")}]
+      assert response.content == [%{"type" => "text", "text" => "Secret data"}]
     end
 
     test "denies access for non-admin" do
@@ -73,14 +73,14 @@ defmodule Ectomancer.ToolAuthorizationTest do
       frame = %{assigns: %{ectomancer_actor: %{role: :anonymous}}}
 
       assert {:reply, response, _} = PublicAction.execute(%{}, frame)
-      assert response.content == [%{"type" => "text", "text" => ~s("Public data")}]
+      assert response.content == [%{"type" => "text", "text" => "Public data"}]
     end
 
     test "allows access with nil actor" do
       frame = %{assigns: %{}}
 
       assert {:reply, response, _} = PublicAction.execute(%{}, frame)
-      assert response.content == [%{"type" => "text", "text" => ~s("Public data")}]
+      assert response.content == [%{"type" => "text", "text" => "Public data"}]
     end
   end
 
@@ -89,7 +89,7 @@ defmodule Ectomancer.ToolAuthorizationTest do
       frame = %{assigns: %{ectomancer_actor: %{role: :admin}}}
 
       assert {:reply, response, _} = WithPolicy.execute(%{}, frame)
-      assert response.content == [%{"type" => "text", "text" => ~s("Protected data")}]
+      assert response.content == [%{"type" => "text", "text" => "Protected data"}]
     end
 
     test "denies access when policy returns error" do
@@ -106,7 +106,7 @@ defmodule Ectomancer.ToolAuthorizationTest do
       frame = %{assigns: %{ectomancer_actor: %{role: :any}}}
 
       assert {:reply, response, _} = DefaultAuth.execute(%{}, frame)
-      assert response.content == [%{"type" => "text", "text" => ~s("Default data")}]
+      assert response.content == [%{"type" => "text", "text" => "Default data"}]
     end
   end
 end


### PR DESCRIPTION
## Summary

Four defects from the 1.6.0 integration shakedown, all v1.7.0 non-breaking:

### #145 — Batch operations silently no-op (`total: 0`)

Anubis validates against the Peri schema and delivers params with **atom keys**, but all batch handlers read string keys (`"records"`, `"ids"`). `Map.get(%{records: [...]}, "records", [])` → `[]`, so every batch call reported success with zero records.

- `do_execute/5` (tool execution funnel) now normalizes top-level param keys atom→string once.
- `Repo.batch_*` read `records`/`ids` with either key shape (`batch_entries/2`).

### #146 — `include`/`preloadable` silently ignored, then crashed

Same key mismatch hid `Map.pop(params, "include", nil)`. Once unmasked, `validate_includes/3` crashed calling `Atom.to_string/1` on already-string allowlists.

- `validate_includes/3` normalizes both `include` entries and the allowed list via `to_string/1`.
- Removed the dead `:all` clause (unreachable, and the only place doing unbounded `String.to_atom` on caller input).

### #147 — Tool results are `inspect/1` output, not JSON

- `do_execute/5` now emits `Ectomancer.Output.encode!/1` (JSON) instead of `inspect(data)`. Structs → plain maps, `__meta__` dropped, `NotLoaded` → `null`, datetimes → ISO-8601, no more silent 50-row truncation.
- Error responses no longer echo full stacktraces.

### #153 — Batch operations claim atomicity, don't roll back, and can poison the transaction

- Each per-item write now runs in `mode: :savepoint` so a DB-level constraint violation (FK/unique) can't abort the surrounding transaction.
- Documented partial-failure semantics kept; README table and wording corrected (no longer claims "atomically" / "validates all").

**Tests:** new `test/ectomancer/batch_output_include_test.exs` (10 tests) covering JSON output shape, atom-keyed batch params, tool-level `include` preloading, and savepoint isolation under a unique-constraint failure. Updated stale `validate_includes` and tool-auth string assertions.

**Verification:** 853 tests pass, Credo clean, `mix format` clean.