### PR TITLE
fix: prevent remote atom-table exhaustion; make list limit cap configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`scope:` option for `expose`** — row-level scoping for multi-tenant apps. The function receives the query and the authenticated actor (`fn query, actor -> query end`) and is applied to every generated CRUD query. Composes with authorization-policy scopes.
+- **Configurable query limit ceiling** — `config :ectomancer, max_limit: N` (default `100`). The effective `limit` is reported in pagination metadata so clamping is visible (#150).
 
 ### Changed
 - **anubis_mcp requirement tightened to `~> 1.14`** (was `~> 1.5`). The old range resolved the current release anyway; the constraint now reflects what is actually tested.
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Batch operations no longer silently no-op** (#145). Anubis delivers params with atom keys; the batch handlers read string keys, so `batch_create` reported `total: 0`. Param keys are now normalized once at the tool-execution funnel, and `Repo.batch_*` read both key shapes.
 - **`include`/`preloadable` actually preloads** (#146). The `include` param is honored after the key-normalization fix, and `validate_includes/3` no longer crashes on string allowlists (removed the dead `:all` clause that also did unbounded `String.to_atom`).
 - **Batch operations isolate per-record failures** (#153). Each per-item write runs in a savepoint so a database-level constraint violation cannot poison the surrounding transaction; the documented partial-failure semantics are kept and the README no longer claims batches are atomic.
+- **No unbounded atom creation from remote input** (#142). `order_by`, filter keys, and param names were `String.to_atom`'d from caller-influenced strings before the allowlist check, letting an unauthenticated client exhaust the BEAM atom table. Filtering now resolves against the schema's field allowlist by string comparison and only ever references existing atoms.
 - **`only:`/`except:` now redact read results** — excluded fields are stripped from every row returned by `list`, `get`, and batch tools (previously they only affected input params and resource metadata).
 - **Tool name pluralization** — `singularize_resource/1` now uses `Plurality` for noun inflection and keeps already-singular words ending in "s" intact. Tool names for `status`, `analysis`, `business`, `series`, `class`, `address`, and `news` are no longer truncated (`get_status` instead of `get_statu`, etc.) (#128)
 - **Compile warnings** — grouped `build_assoc_params/1` clauses and silenced the unused `assoc` parameter in `child_fk/3` so the lint CI job (`--warnings-as-errors`) passes.

--- a/README.md
+++ b/README.md
@@ -335,6 +335,18 @@ expose_oban_jobs authorize: [
 config :ectomancer, repo: MyApp.Repo
 ```
 
+### Query limits
+
+`list` results are capped to `100` rows per call by default. Raise (or lower)
+the ceiling globally:
+
+```elixir
+config :ectomancer, max_limit: 500
+```
+
+The effective limit is always reported in the `pagination` metadata of a
+paginated `list` response, so clients can see when a request was clamped.
+
 ### Actor extraction
 
 ```elixir

--- a/lib/ectomancer/repo.ex
+++ b/lib/ectomancer/repo.ex
@@ -84,6 +84,8 @@ if Code.ensure_loaded?(Ecto) do
                 Filtering.parse_int(Map.get(meta_params, "limit")) ||
                   Keyword.get(opts, :limit, 100)
 
+              effective_limit = min(limit_val, Filtering.max_limit())
+
               offset_val =
                 Filtering.parse_int(Map.get(meta_params, "offset")) ||
                   Keyword.get(opts, :offset, 0)
@@ -99,9 +101,9 @@ if Code.ensure_loaded?(Ecto) do
                  data: results,
                  pagination: %{
                    total: total,
-                   limit: limit_val,
+                   limit: effective_limit,
                    offset: offset_val,
-                   has_more: offset_val + limit_val < total
+                   has_more: offset_val + effective_limit < total
                  }
                }}
             else
@@ -866,22 +868,22 @@ if Code.ensure_loaded?(Ecto) do
     defdelegate parse_int(val), to: Filtering
 
     defp normalize_params(params, schema_module) do
-      introspection = SchemaIntrospection.analyze(schema_module)
-      types = introspection.types
+      types = SchemaIntrospection.analyze(schema_module).types
 
       params
       |> Enum.map(fn
         {k, v} when is_atom(k) ->
-          type = Map.get(types, k)
-          value = cast_param_value(v, type)
-          {k, value}
+          {k, cast_param_value(v, Map.get(types, k))}
 
         {k, v} when is_binary(k) ->
-          field = String.to_atom(k)
-          type = Map.get(types, field)
-          value = cast_param_value(v, type)
-          {field, value}
+          case Enum.find(Map.keys(types), &(Atom.to_string(&1) == k)) do
+            # Unknown string keys are dropped — never atomized from caller input
+            # (see #142) and rejected by changeset casting anyway.
+            nil -> nil
+            field -> {field, cast_param_value(v, Map.get(types, field))}
+          end
       end)
+      |> Enum.reject(&is_nil/1)
       |> Enum.into(%{})
     end
 

--- a/lib/ectomancer/repo/filtering.ex
+++ b/lib/ectomancer/repo/filtering.ex
@@ -8,6 +8,19 @@ if Code.ensure_loaded?(Ecto) do
 
     @meta_keys ~w(order_by order_dir limit offset include_deleted)
 
+    # Suffix -> operator. Ordered longest-first so compound suffixes match
+    # before their prefixes would be misread (e.g. `_gte` before `_gt`).
+    @filter_ops [
+      {"_gte", :gte},
+      {"_lte", :lte},
+      {"_contains", :contains},
+      {"_icontains", :icontains},
+      {"_gt", :gt},
+      {"_lt", :lt},
+      {"_in", :in},
+      {"_not", :not}
+    ]
+
     @doc false
     def extract_meta_params(params) do
       {meta, filters} =
@@ -21,27 +34,27 @@ if Code.ensure_loaded?(Ecto) do
       base_query = from(r in schema_module)
 
       Enum.reduce(params, base_query, fn {field_str, value}, query ->
-        {field, operator} = parse_filter_key(to_string(field_str))
+        {field_name, operator} = parse_filter_key(to_string(field_str))
 
-        if field in fields do
-          apply_filter(query, field, operator, value)
-        else
-          query
+        case find_field(fields, field_name) do
+          nil -> query
+          field -> apply_filter(query, field, operator, value)
         end
       end)
     end
 
     @doc false
     def parse_filter_key(key) do
-      suffixes = ~w(_gte _gt _lte _lt _contains _icontains _in _not)
+      case Enum.find(@filter_ops, fn {suffix, _op} -> String.ends_with?(key, suffix) end) do
+        nil -> {key, :eq}
+        {suffix, op} -> {String.replace_trailing(key, suffix, ""), op}
+      end
+    end
 
-      Enum.find_value(suffixes, {String.to_atom(key), :eq}, fn suffix ->
-        if String.ends_with?(key, suffix) do
-          base = String.replace_trailing(key, suffix, "")
-          op = suffix |> String.trim_leading("_") |> String.to_atom()
-          {String.to_atom(base), op}
-        end
-      end)
+    # Resolves a caller-supplied field name against the schema's fields without
+    # minting new atoms (see #142 — remote atom-table exhaustion).
+    defp find_field(fields, name) do
+      Enum.find(fields, &(Atom.to_string(&1) == name))
     end
 
     defp apply_filter(query, field, :eq, nil) do
@@ -105,13 +118,13 @@ if Code.ensure_loaded?(Ecto) do
     def apply_ordering(query, meta, fields) do
       case meta do
         %{"order_by" => order_field} ->
-          field = String.to_atom(to_string(order_field))
-          dir = parse_order_dir(Map.get(meta, "order_dir", "asc"))
+          case find_field(fields, to_string(order_field)) do
+            nil ->
+              query
 
-          if field in fields do
-            order_by(query, [r], [{^dir, field(r, ^field)}])
-          else
-            query
+            field ->
+              dir = parse_order_dir(Map.get(meta, "order_dir", "asc"))
+              order_by(query, [r], [{^dir, field(r, ^field)}])
           end
 
         _ ->
@@ -135,11 +148,16 @@ if Code.ensure_loaded?(Ecto) do
       limit_val = parse_int(Map.get(meta, "limit")) || Keyword.get(opts, :limit, 100)
       offset_val = parse_int(Map.get(meta, "offset")) || Keyword.get(opts, :offset, 0)
 
-      limit_val = min(limit_val, 100)
+      limit_val = min(limit_val, max_limit())
 
       query
       |> limit(^limit_val)
       |> offset(^offset_val)
+    end
+
+    @doc false
+    def max_limit do
+      Application.get_env(:ectomancer, :max_limit, 100)
     end
 
     @doc false

--- a/test/ectomancer/repo_test.exs
+++ b/test/ectomancer/repo_test.exs
@@ -549,27 +549,27 @@ defmodule Ectomancer.RepoTest do
 
   describe "parse_filter_key/1" do
     test "returns :eq for plain field name" do
-      assert Repo.parse_filter_key("email") == {:email, :eq}
+      assert Repo.parse_filter_key("email") == {"email", :eq}
     end
 
     test "detects comparison suffixes" do
-      assert Repo.parse_filter_key("age_gte") == {:age, :gte}
-      assert Repo.parse_filter_key("age_gt") == {:age, :gt}
-      assert Repo.parse_filter_key("age_lte") == {:age, :lte}
-      assert Repo.parse_filter_key("age_lt") == {:age, :lt}
+      assert Repo.parse_filter_key("age_gte") == {"age", :gte}
+      assert Repo.parse_filter_key("age_gt") == {"age", :gt}
+      assert Repo.parse_filter_key("age_lte") == {"age", :lte}
+      assert Repo.parse_filter_key("age_lt") == {"age", :lt}
     end
 
     test "detects string matching suffixes" do
-      assert Repo.parse_filter_key("name_contains") == {:name, :contains}
-      assert Repo.parse_filter_key("name_icontains") == {:name, :icontains}
+      assert Repo.parse_filter_key("name_contains") == {"name", :contains}
+      assert Repo.parse_filter_key("name_icontains") == {"name", :icontains}
     end
 
     test "detects list suffix" do
-      assert Repo.parse_filter_key("status_in") == {:status, :in}
+      assert Repo.parse_filter_key("status_in") == {"status", :in}
     end
 
     test "detects not-equal suffix" do
-      assert Repo.parse_filter_key("field_not") == {:field, :not}
+      assert Repo.parse_filter_key("field_not") == {"field", :not}
     end
   end
 

--- a/test/ectomancer/security_and_limit_test.exs
+++ b/test/ectomancer/security_and_limit_test.exs
@@ -1,0 +1,120 @@
+defmodule Ectomancer.SecurityAndLimitTest do
+  @moduledoc """
+  Tests for atom-exhaustion hardening (#142) and the configurable limit cap (#150).
+  """
+
+  use Ectomancer.DataCase
+
+  alias Ectomancer.Repo
+  alias Ectomancer.TestRepo
+
+  defmodule Item do
+    use Ecto.Schema
+
+    schema "sec_items" do
+      field(:name, :string)
+      field(:price, :integer)
+
+      timestamps()
+    end
+  end
+
+  @moduletag schemas: [Item]
+
+  setup %{repo: _repo} do
+    Application.put_env(:ectomancer, :repo, TestRepo)
+
+    on_exit(fn ->
+      Application.delete_env(:ectomancer, :repo)
+    end)
+
+    :ok
+  end
+
+  describe "atom exhaustion hardening (#142)" do
+    test "order_by with an unknown value mints no atoms" do
+      probe = "ectomancer_probe_#{System.unique_integer([:positive])}"
+      insert!(Item, %{name: "A", price: 1})
+
+      assert {:ok, _} = Repo.list(Item, %{"order_by" => probe})
+      assert_raise ArgumentError, fn -> String.to_existing_atom(probe) end
+    end
+
+    test "order_by with an unknown suffixed value mints no atoms" do
+      probe = "ectomancer_probe_gt_#{System.unique_integer([:positive])}"
+      insert!(Item, %{name: "A", price: 1})
+
+      assert {:ok, _} = Repo.list(Item, %{"order_by" => probe})
+      assert_raise ArgumentError, fn -> String.to_existing_atom(probe) end
+    end
+
+    test "filter keys with unknown fields mint no atoms" do
+      probe = "ectomancer_fk_#{System.unique_integer([:positive])}"
+      insert!(Item, %{name: "A", price: 1})
+
+      assert {:ok, _} = Repo.list(Item, %{probe => "x"})
+      assert_raise ArgumentError, fn -> String.to_existing_atom(probe) end
+    end
+
+    test "suffixed unknown fields mint no atoms" do
+      probe = "ectomancer_fk_gt_#{System.unique_integer([:positive])}"
+      insert!(Item, %{name: "A", price: 1})
+
+      assert {:ok, _} = Repo.list(Item, %{probe => 5})
+      assert_raise ArgumentError, fn -> String.to_existing_atom(probe) end
+    end
+
+    test "valid order_by fields still work" do
+      insert!(Item, %{name: "B", price: 2})
+      insert!(Item, %{name: "A", price: 1})
+
+      assert {:ok, [%{name: "A"}, %{name: "B"}]} = Repo.list(Item, %{"order_by" => "name"})
+    end
+
+    test "unknown attribute values passed to create/update never mint atoms" do
+      probe = "ectomancer_attr_#{System.unique_integer([:positive])}"
+
+      assert {:ok, _} = Repo.create(Item, Map.put(%{name: "A"}, probe, "x"))
+      assert_raise ArgumentError, fn -> String.to_existing_atom(probe) end
+    end
+  end
+
+  describe "configurable max limit (#150)" do
+    setup do
+      for i <- 1..5 do
+        insert!(Item, %{name: "Item#{i}", price: i})
+      end
+
+      :ok
+    end
+
+    test "default cap is 100" do
+      Application.delete_env(:ectomancer, :max_limit)
+
+      assert {:ok, %{data: data, pagination: %{limit: 100}}} = Repo.list(Item, %{"limit" => 500})
+      assert length(data) == 5
+    end
+
+    test "max_limit raises the ceiling" do
+      Application.put_env(:ectomancer, :max_limit, 10_000)
+
+      on_exit(fn ->
+        Application.delete_env(:ectomancer, :max_limit)
+      end)
+
+      assert {:ok, %{data: data, pagination: %{limit: 500}}} = Repo.list(Item, %{"limit" => 500})
+      assert length(data) == 5
+    end
+
+    test "reports the effective clamped limit" do
+      Application.put_env(:ectomancer, :max_limit, 3)
+
+      on_exit(fn ->
+        Application.delete_env(:ectomancer, :max_limit)
+      end)
+
+      assert {:ok, %{data: data, pagination: %{limit: 3}}} = Repo.list(Item, %{"limit" => 500})
+      assert length(data) == 3
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two v1.7.0 non-breaking fixes from the shakedown:

### #142 — Remote unbounded atom creation via `order_by` → BEAM atom-table DoS

`String.to_atom(to_string(order_field))` ran **before** the allowlist check, so rejected values still consumed atom-table slots. 500 `tools/call` with `order_by = "ectomancer_atom_probe_<i>"` minted 500 resident atoms.

- `filtering.ex` now resolves `order_by`, plain filter keys, and suffixed keys against the schema's field allowlist **by string comparison**, converting to an atom only after the value is confirmed to be an existing schema field.
- `normalize_params/2` (repo.ex) drops unknown string params instead of `String.to_atom`ing them.
- `parse_filter_key/1` returns string field names + operator atoms (no runtime atom minting).

Regression tests probe with unique strings and assert `String.to_existing_atom/1` raises afterwards.

### #150 — `limit` silently hard-capped at 100

- The ceiling is now configurable: `config :ectomancer, max_limit: N` (default `100`).
- Paginated `list` responses report the **effective** clamped `limit` in `pagination`, so callers can see when a request was capped.

**Tests:** new `test/ectomancer/security_and_limit_test.exs` (9 tests) + updated `parse_filter_key` assertions.

**Verification:** 859 tests pass, Credo clean, `mix format` clean.