### PR TITLE
fix: child_spec/2 returns a single child spec, not a list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,13 @@ jobs:
       if: ${{ !matrix.lint }}
       run: mix compile
 
+    - name: Compile dependencies (lint)
+      if: ${{ matrix.lint }}
+      run: mix deps.compile
+
     - name: Compile with warnings as errors
       if: ${{ matrix.lint }}
-      run: mix deps.compile && mix compile --warnings-as-errors
+      run: mix compile --warnings-as-errors
 
     - name: Check formatting
       if: ${{ matrix.lint }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **anubis_mcp requirement tightened to `~> 1.14`** (was `~> 1.5`). The old range resolved the current release anyway; the constraint now reflects what is actually tested.
 - **`Ectomancer.child_spec/2` produces a working supervision entry.** The old output `{Anubis.Server.Supervisor, {server, transport: ...}}` called the non-existent `start_link/1` and failed at boot (#143, #148). It now returns `{server, transport: {transport, start: true}}`, resolved through the server module's own `child_spec/1`. One transport per server module is supported (anubis registers process names per server); requesting two raises a clear error.
+- **`Ectomancer.child_spec/2` returns a single child spec** (not a one-element list), so `children = [Ectomancer.child_spec(MyApp.MCP, transports: [:streamable_http]), MyAppWeb.Endpoint]` actually boots instead of nesting a list in the supervision tree.
 - **Router mounting works on anubis 1.14.** `Ectomancer.Plug.init/1` now passes an escapable `subscriber_metadata` remote capture so `forward "/mcp", Ectomancer.Plug, ...` compiles in Phoenix/Plug routers instead of failing with "cannot inject attribute @plug_forward_opts" (#143).
 - README + `Ectomancer.Plug` docs updated to the working supervision form.
 

--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -188,7 +188,7 @@ defmodule Ectomancer do
   the same server collides. Use a dedicated server module per transport when
   you need to serve multiple transports.
   """
-  @spec child_spec(module(), keyword()) :: Supervisor.child_spec()
+  @spec child_spec(module(), keyword()) :: {module(), keyword()}
   def child_spec(server, opts) do
     case Keyword.get(opts, :transports) do
       nil ->

--- a/lib/ectomancer.ex
+++ b/lib/ectomancer.ex
@@ -167,7 +167,7 @@ defmodule Ectomancer do
   end
 
   @doc """
-  Generates child specifications for the Anubis transport supervisors.
+  Generates the child specification for the Anubis transport supervisor.
 
   Use in your application's supervision tree to start the transport backend
   required by the Ectomancer plug:
@@ -180,7 +180,7 @@ defmodule Ectomancer do
 
   ## Options
 
-    * `:transports` — a list with a single transport atom (required).
+    * `:transports` — a single transport atom or a one-element list (required).
       Supported values: `:streamable_http`, `:sse`.
 
   One transport is supported per server module. `anubis_mcp` registers
@@ -188,7 +188,7 @@ defmodule Ectomancer do
   the same server collides. Use a dedicated server module per transport when
   you need to serve multiple transports.
   """
-  @spec child_spec(module(), keyword()) :: [Supervisor.child_spec()]
+  @spec child_spec(module(), keyword()) :: Supervisor.child_spec()
   def child_spec(server, opts) do
     case Keyword.get(opts, :transports) do
       nil ->
@@ -205,10 +205,13 @@ defmodule Ectomancer do
                 "`Ectomancer.child_spec(MyApp.MCP, transports: [:streamable_http])`."
 
       transports when is_list(transports) ->
-        Enum.map(transports, &child_spec_for_transport(server, &1))
+        case transports do
+          [transport] -> child_spec_for_transport(server, transport)
+          [] -> raise ArgumentError, "Ectomancer.child_spec/2 :transports must not be empty."
+        end
 
       transport ->
-        [child_spec_for_transport(server, transport)]
+        child_spec_for_transport(server, transport)
     end
   end
 

--- a/lib/ectomancer/igniter.ex
+++ b/lib/ectomancer/igniter.ex
@@ -209,13 +209,8 @@ defmodule Ectomancer.Igniter do
 
   defp add_transport_supervisor(igniter, app_mod, module_atom, module_name, transport) do
     if Code.ensure_loaded?(app_mod) && function_exported?(app_mod, :add_new_child, 2) do
-      specs =
-        Ectomancer.child_spec(module_atom, transports: [transport])
-        |> Enum.map(fn {mod, args} -> {mod, args} end)
-
-      Enum.reduce(specs, igniter, fn spec, acc ->
-        app_mod.add_new_child(acc, spec)
-      end)
+      spec = Ectomancer.child_spec(module_atom, transports: [transport])
+      app_mod.add_new_child(igniter, spec)
     else
       unless Mix.env() == :test do
         print_manual_supervisor_instruction(module_name, transport)

--- a/test/ectomancer/child_spec_test.exs
+++ b/test/ectomancer/child_spec_test.exs
@@ -7,7 +7,7 @@ defmodule Ectomancer.ChildSpecTest do
 
   describe "Ectomancer.child_spec/2" do
     test "returns a valid single child spec through the server module" do
-      assert [{TestMCP, transport: {:streamable_http, start: true}}] =
+      assert {TestMCP, transport: {:streamable_http, start: true}} =
                Ectomancer.child_spec(TestMCP, transports: [:streamable_http])
 
       # The server module's child_spec/1 (from `use Anubis.Server`) produces the
@@ -20,7 +20,7 @@ defmodule Ectomancer.ChildSpecTest do
     end
 
     test "accepts a bare transport atom" do
-      assert [{TestMCP, transport: {:sse, start: true}}] =
+      assert {TestMCP, transport: {:sse, start: true}} =
                Ectomancer.child_spec(TestMCP, transports: :sse)
     end
 
@@ -48,11 +48,6 @@ defmodule Ectomancer.ChildSpecTest do
       assert_raise ArgumentError, ~r/:transports option/, fn ->
         Ectomancer.child_spec(TestMCP, [])
       end
-    end
-
-    test "the broken tuple form no longer appears in generated specs" do
-      [{spec, _opts}] = Ectomancer.child_spec(TestMCP, transports: [:streamable_http])
-      assert spec == TestMCP
     end
   end
 end

--- a/test/ectomancer_test.exs
+++ b/test/ectomancer_test.exs
@@ -14,10 +14,9 @@ defmodule EctomancerTest do
     end
 
     test "generates spec for a single transport" do
-      specs = Ectomancer.child_spec(MyApp.MCP, transports: [:streamable_http])
-      assert length(specs) == 1
+      spec = Ectomancer.child_spec(MyApp.MCP, transports: [:streamable_http])
 
-      {mod, args} = hd(specs)
+      {mod, args} = spec
       assert mod == MyApp.MCP
       assert Keyword.get(args, :transport) == {:streamable_http, start: true}
     end


### PR DESCRIPTION
## Summary

**Found by the E2E Phoenix install.** The documented pattern

```elixir
children = [
  Ectomancer.child_spec(MyApp.MCP, transports: [:streamable_http]),
  MyAppWeb.Endpoint
]
```

failed at boot with `supervisors expect each child to be one of... Got: [{EctomancerE2e.MCP, [transport: ...]}]` — `child_spec/2` returned a **one-element list**, nesting a list inside the supervision tree (Bug #148 was only half-resolved: the tuple-form crash was fixed, but the list nesting remained).

`Ectomancer.child_spec/2` now returns a **single** `{server, transport: {transport, start: true}}` spec, so the README usage boots as written.

**Verification:** 873 tests pass, Credo clean, `mix format` clean.